### PR TITLE
bugfix: m1911 energy gun projectile speed

### DIFF
--- a/modular_ss220/modules/weapons_addon/code/energy1911.dm
+++ b/modular_ss220/modules/weapons_addon/code/energy1911.dm
@@ -60,7 +60,6 @@
 /obj/projectile/beam/m1911
 	name = "focused laser beam"
 	hitscan = FALSE
-	speed = 0.6
 	damage = 20
 	wound_bonus = -40
 	icon_state = "laser"


### PR DESCRIPTION
## Changelog

:cl:
bugfix: Nanotrasen Consultant m1911 gun now have default projectile speed (instead of slow-mode like)
/:cl: