### PR TITLE
qol: More charge at engineering SMES + higher capacity for all SMES

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -340,7 +340,7 @@
 	build_path = /obj/machinery/power/smes
 	req_components = list(
 		/obj/item/stack/cable_coil = 5,
-		/obj/item/stock_parts/power_store/battery = 5,
+		/obj/item/stock_parts/power_store/battery = 10, //SS1984 EDIT
 		/datum/stock_part/capacitor = 1)
 	def_components = list(/obj/item/stock_parts/power_store/battery = /obj/item/stock_parts/power_store/battery/high/empty)
 
@@ -358,7 +358,7 @@
 	build_path = /obj/machinery/power/smesbank
 	req_components = list(
 		/obj/item/stack/cable_coil = 5,
-		/obj/item/stock_parts/power_store/battery = 5,)
+		/obj/item/stock_parts/power_store/battery = 10,) // SS1984 EDIT
 	def_components = list(/obj/item/stock_parts/power_store/battery = /obj/item/stock_parts/power_store/battery/high/empty)
 
 /obj/item/circuitboard/machine/techfab/department/engineering

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -24,7 +24,7 @@
 	can_change_cable_layer = TRUE
 
 	/// The charge capacity.
-	var/capacity = 50 * STANDARD_BATTERY_CHARGE // The board defaults with 5 high capacity batteries.
+	var/capacity = 100 * STANDARD_BATTERY_CHARGE // SS1984 EDIT The board defaults with 10 high capacity batteries.
 	/// The current charge.
 	var/charge = 0
 
@@ -469,19 +469,19 @@
 	name = "super capacity power storage unit"
 	desc = "A super-capacity superconducting magnetic energy storage (SMES) unit. Relatively rare, and typically installed in long-range outposts where minimal maintenance is expected."
 	circuit = /obj/item/circuitboard/machine/smes/super
-	capacity = 100 * STANDARD_BATTERY_CHARGE
+	capacity = 200 * STANDARD_BATTERY_CHARGE // SS1984 EDIT
 
 /obj/machinery/power/smes/super/full
-	charge = 100 * STANDARD_BATTERY_CHARGE
+	charge = 200 * STANDARD_BATTERY_CHARGE  // SS1984 EDIT
 
 /obj/machinery/power/smes/full
-	charge = 50 * STANDARD_BATTERY_CHARGE
+	charge = 100 * STANDARD_BATTERY_CHARGE  // SS1984 EDIT
 
 /obj/machinery/power/smes/ship
 	charge = 20 * STANDARD_BATTERY_CHARGE
 
 /obj/machinery/power/smes/engineering
-	charge = 50 * STANDARD_BATTERY_CHARGE // Engineering starts with some charge for singulo //sorry little one, singulo as engine is gone
+	charge = 100 * STANDARD_BATTERY_CHARGE  // SS1984 EDIT, SMESES FOR ENGINE
 	output_level = 90 KILO WATTS
 
 /obj/machinery/power/smes/magical


### PR DESCRIPTION
SMESы инженерки теперь имеют вдвое выше вместимость (Super-SMESы соответственно еще вдвое выше этого)
Заряд на стартовых SMESах в инженерке повышен до нового максимума
Взамен - для сбора SMESа нужно 10 батареек вместо 5

## Changelog

:cl:
qol: SMES now have double capacity (5MJ->10MJ/10MJ->20MJ)
qol: More roundstart charge for engineering SMES (5MJ->10MJ)
balance: SMES now contains/require double power-cells (5->10)
/:cl: