### PR TITLE
add: more elite telescopic

### DIFF
--- a/modular_ss220/modules/return_prs/sec_haul/code/cmg.dm
+++ b/modular_ss220/modules/return_prs/sec_haul/code/cmg.dm
@@ -252,7 +252,7 @@
 		/obj/item/clothing/head/collectable/captain = 4,
 	)
 
-	veteran_only = TRUE
+	veteran_only = FALSE // ss1984 edit original TRUE
 	job_flags = STATION_JOB_FLAGS | JOB_CANNOT_OPEN_SLOTS
 
 

--- a/modular_ss220/modules/weapons_addon/code/energy1911.dm
+++ b/modular_ss220/modules/weapons_addon/code/energy1911.dm
@@ -151,7 +151,7 @@
 		/obj/item/reagent_containers/cup/glass/bottle/champagne = 10
 	)
 
-	veteran_only = TRUE
+	veteran_only = FALSE //ss1984 edit original TRUE
 	job_flags = STATION_JOB_FLAGS | JOB_BOLD_SELECT_TEXT | JOB_CANNOT_OPEN_SLOTS
 
 /datum/id_trim/job/nanotrasen_consultant
@@ -225,7 +225,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	head = /obj/item/clothing/head/nanotrasen_consultant
 	backpack_contents = list(
-		/obj/item/melee/baton/telescopic = 1,
+		/obj/item/melee/baton/telescopic/gold = 1,
 		/obj/item/choice_beacon/ntc = 1,
 		)
 


### PR DESCRIPTION

## Changelog
Заменил обычную телескопичную дубинку на более подходящую по статусу,
убрал с модульного оверрайда необходимость в ветеранке

:cl:
add: Replaced basic telescopic baton with more elite version
qol: Removed veteran req for NTR/BS
/:cl:
