### PR TITLE
admin: +ADMIN flag to write to admin chat

### DIFF
--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(cmd_admin_say, R_NONE, "ASay", "Send a message to other admins", ADMIN_CATEGORY_MAIN, message as text)
+ADMIN_VERB(cmd_admin_say, R_ADMIN, "ASay", "Send a message to other admins", ADMIN_CATEGORY_MAIN, message as text) // SS1984 EDIT
 	message = emoji_parse(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 	if(!message)
 		return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1047,7 +1047,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 				if("South")
 					movement_keys[key] = SOUTH
 				if(ADMIN_CHANNEL)
-					if(holder)
+					if(holder && check_rights(R_ADMIN,show_msg=0)) // SS1984 EDIT
 						var/asay = tgui_say_create_open_command(ADMIN_CHANNEL)
 						winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[asay]")
 					else

--- a/modular_nova/modules/admin/code/loud_say.dm
+++ b/modular_nova/modules/admin/code/loud_say.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(cmd_loud_admin_say, R_NONE, "loudAsay", "Send a message to other admins (loudly).", ADMIN_CATEGORY_MAIN, msg as text)
+ADMIN_VERB(cmd_loud_admin_say, R_ADMIN, "loudAsay", "Send a message to other admins (loudly).", ADMIN_CATEGORY_MAIN, msg as text)
 	msg = emoji_parse(copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN))
 	if(!msg)
 		return


### PR DESCRIPTION
Менторы/кодеры и т.д. могли писать в админ-чат, но не видели его. Решения были следующие:
1. Разрешить им видеть админ-чат
2. Убрать возможность писать в админ-чат, если не видишь его
ГА выбрал второе.