### PR TITLE
server: Temporaly exclude ouroboros from map vote

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -86,7 +86,7 @@ endmap
 
 map ouroboros
 	maxplayers 80
-	votable
+# SS1984 EDIT - suspected for not fixed lagging at FastProcessing - temporaly nonvotable	votable
 endmap
 
 map serenitystation


### PR DESCRIPTION
Еще не выяснено почему, но FastProcessing начинает лагать хуже атмоса при взрыве СМа на 30+ тайлов. Утилизация контроллера происходит преимущественно на карте ouroboros. Так как карт достаточно много, временно убираем эту из ротации, пока не поймем связаны ли лаги с ней/как их фиксить

:cl:
server: Ouroboros map temporaly excluded from map vote
/:cl: