### PR TITLE
config: min_players for spies reduced

### DIFF
--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -390,6 +390,7 @@
 			"weight": 2,
 			"required_candidates": 1,
 			"minimum_required_age": 0,
+			"minimum_players": 5,
 			"requirements": [
 				10,
 				10,


### PR DESCRIPTION
## Changelog

:cl:
config: Min players for roundstart spies 10 -> 5
/:cl: