### PR TITLE
add: Role preference for cortical borer + correct pooling

### DIFF
--- a/modular_nova/modules/cortical_borer/code/cortical_borer_antag.dm
+++ b/modular_nova/modules/cortical_borer/code/cortical_borer_antag.dm
@@ -127,7 +127,7 @@
 		return MAP_ERROR
 	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates(
 		"Do you want to spawn as a cortical borer?",
-		role = ROLE_PAI,
+		role = ROLE_BORER,
 		check_jobban = FALSE,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_CORTICAL_BORER,

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/borer.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/borer.ts
@@ -1,0 +1,16 @@
+import { Antagonist, Category } from '../base';
+
+const Borer: Antagonist = {
+  key: 'borer',
+  name: 'Cortical Borer',
+  description: [
+    `
+    A cortical borer has appeared on station. It will also attempt to produce eggs, and will attempt to gather willing hosts and learn chemicals through the blood.
+    You are a cortical borer! You can fear someone to make them stop moving, but make sure to inhabit them!
+    You only grow/heal/talk when inside a host!
+    `,
+  ],
+  category: Category.Midround,
+};
+
+export default Borer;


### PR DESCRIPTION
## Changelog

:cl:
add: Preference for cortical borer to allow spawn as them in midround event
/:cl:
