### PR TITLE
add: Return of materials market that was disabled by nova

### DIFF
--- a/config/ss220/ss220_config.txt
+++ b/config/ss220/ss220_config.txt
@@ -16,3 +16,6 @@ AUTO_CRYO_SSD_MIN 25
 ## A command to run prior to the world shutting down, only used if the above option is enabled
 ## This default value will kill Dream Daemon on Windows machines
 #SHUTDOWN_SHELL_COMMAND taskkill /f /im dreamdaemon.exe
+
+# Uncomment to allow send to galactic market as it was forbidden by nova
+ALLOW_GALACTIC_MARKET_SELL

--- a/modular_nova/modules/economy/code/materials_market.dm
+++ b/modular_nova/modules/economy/code/materials_market.dm
@@ -7,6 +7,10 @@
 
 /obj/machinery/materials_market/attackby(obj/item/attacking_item, mob/user, params)
 	if(is_type_in_list(attacking_item, exportable_material_items))
+		// SS1984 ADDITION START
+		if (CONFIG_GET(flag/allow_galactic_market_sell))
+			return ..()
+		// SS1984 ADDITION END
 		say("Selling materials to the GMM is no longer available due to volatile logistics conditions in frontier space. Please export your materials via standard Union-NT cargo arrangements.")
 		playsound(src, 'sound/machines/scanner/scanbuzz.ogg', 25, FALSE)
 		return TRUE

--- a/modular_ss220/modules/galactic_market_return/galactic_market_config.dm
+++ b/modular_ss220/modules/galactic_market_return/galactic_market_config.dm
@@ -1,0 +1,1 @@
+/datum/config_entry/flag/allow_galactic_market_sell

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9181,4 +9181,5 @@
 #include "modular_ss220\modules\extra_tips\mob\dead\new_player\new_player.dm"
 #include "modular_ss220\modules\dynamic_tweaks\dynamic_tweaks.dm"
 #include "modular_ss220\modules\dynamic_tweaks\dynamic_progressive.dm"
+#include "modular_ss220\modules\galactic_market_return\galactic_market_config.dm"
 // END_INCLUDE


### PR DESCRIPTION
https://github.com/NovaSector/NovaSector/pull/2498

## Changelog

:cl:
add: Galactic Materials Market now accepts selling materials as it was before Nova's disabled it
config: New config flag for Galactic Market sell
/:cl: