### PR TITLE
admin: admins proper cancel non-recallable shuttles

### DIFF
--- a/code/modules/admin/verbs/adminshuttle.dm
+++ b/code/modules/admin/verbs/adminshuttle.dm
@@ -53,6 +53,7 @@ ADMIN_VERB(cancel_shuttle, R_ADMIN, "Cancel Shuttle", "Recall the shuttle, regar
 
 	if(tgui_alert(user, "You sure?", "Confirm", list("Yes", "No")) != "Yes")
 		return
+	SSshuttle.unblock_recall() // SS1984 ADDITION
 	SSshuttle.admin_emergency_no_recall = FALSE
 	SSshuttle.emergency.cancel()
 	BLACKBOX_LOG_ADMIN_VERB("Cancel Shuttle")


### PR DESCRIPTION
## Changelog

:cl:
admin: Admins can properly cancel non-recallable shuttles now (no more need to disable/enable shuttle for that)
/:cl:
