### PR TITLE
server: preload RSC

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -136,7 +136,8 @@
 #endif
 
 #ifndef PRELOAD_RSC //set to:
-#define PRELOAD_RSC 0 // 0 to allow using external resources or on-demand behaviour; //SS220 EDIT CHANGE
+//#define PRELOAD_RSC 0 // 0 to allow using external resources or on-demand behaviour; //SS220 EDIT CHANGE
+#define PRELOAD_RSC 1 // SS1984 SKYRAT EVENT ADDITION, ORIGINAL ABOVE
 #endif // 1 to use the default behaviour;
 								// 2 for preloading absolutely everything;
 


### PR DESCRIPTION
Возможно исправит долгие загрузки интерфейсов в игре (вместо этого начнет загружать их до игры), т.к. CDN на ивентовом сервере нет