### PR TITLE
fix: Progressive Dynamic no more count ghost roles as crew

### DIFF
--- a/modular_ss220/modules/dynamic_tweaks/dynamic_progressive.dm
+++ b/modular_ss220/modules/dynamic_tweaks/dynamic_progressive.dm
@@ -74,6 +74,9 @@ SUBSYSTEM_DEF(progressive_dynamic)
 		if(checked_mob.mind.assigned_role?.departments_list?.Find(/datum/job_department/command))
 			head_amount++
 			continue
+		// No not-crew (ghost roles) or unassigned (at mind, not at card) roles
+		if (!checked_mob.mind.assigned_role || !(checked_mob.mind.assigned_role.job_flags & JOB_CREW_MEMBER))
+			continue
 		crew_amount++ // So technically someone who was brought to station like some ghost role still count as crew, it's a feature
 
 	var/overall_power = calculate_station_power(sec_amount, head_amount, crew_amount)

--- a/modular_ss220/modules/dynamic_tweaks/dynamic_progressive.dm
+++ b/modular_ss220/modules/dynamic_tweaks/dynamic_progressive.dm
@@ -67,17 +67,17 @@ SUBSYSTEM_DEF(progressive_dynamic)
 			var/mob/living/carbon/human/human_mob = checked_mob
 			if (human_mob.has_trauma_type(/datum/brain_trauma/special/obsessed)) // oh no, obsessed HOS is not contributing to station the same way, as heretic engineer...
 				continue
-		// HIGHER PRIORITY CHECKS GOES FIRST, SO HEADS AND ETC ARE SKIPPED IF MOB IN SECURITY
-		if(checked_mob.mind.assigned_role?.departments_list?.Find(/datum/job_department/security))
-			sec_amount++
-			continue
-		if(checked_mob.mind.assigned_role?.departments_list?.Find(/datum/job_department/command))
-			head_amount++
-			continue
 		// No not-crew (ghost roles) or unassigned (at mind, not at card) roles
 		if (!checked_mob.mind.assigned_role || !(checked_mob.mind.assigned_role.job_flags & JOB_CREW_MEMBER))
 			continue
-		crew_amount++ // So technically someone who was brought to station like some ghost role still count as crew, it's a feature
+		// HIGHER PRIORITY CHECKS GOES FIRST, SO HEADS AND ETC ARE SKIPPED IF MOB IN SECURITY
+		if(checked_mob.mind.assigned_role.departments_list?.Find(/datum/job_department/security))
+			sec_amount++
+			continue
+		if(checked_mob.mind.assigned_role.departments_list?.Find(/datum/job_department/command))
+			head_amount++
+			continue
+		crew_amount++
 
 	var/overall_power = calculate_station_power(sec_amount, head_amount, crew_amount)
 	var/threat_increase = calculate_threat_increase(time_in_deciseconds, overall_power)


### PR DESCRIPTION
## Changelog

:cl:
fix: Progressive Dynamic non-station roles (such as ERT or ghost roles) no more increases threat level
/:cl: