### PR TITLE
nttc zlevel fixes, custom role title in radio

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -146,7 +146,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 /atom/movable/proc/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), visible_name = FALSE)
 	//This proc uses [] because it is faster than continually appending strings. Thanks BYOND.
 	// SS1984 ADDITION START
-	var/obj/machinery/announcement_system/announcer = get_announcement_system(/datum/aas_config_entry/nttc_job_indicator_type, src, radio_freq)
+	var/obj/machinery/announcement_system/announcer = get_announcement_system(/datum/aas_config_entry/nttc_job_indicator_type, speaker, radio_freq)
 	var/datum/nttc_configuration/nttc = announcer ? announcer.nttc : null
 	var/obj/item/card/id/id_card = null
 	// SS1984 ADDITION END
@@ -192,8 +192,9 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 	messagepart = " <span class='message'>[messagepart]</span></span>"
 	// SS1984 EDIT START
-	var/job = nttc ? nttc.retrieve_relevant_job(speaker_source, id_card) : null
-	var/job_part = compose_job(speaker, raw_message, radio_freq, namepart, announcer, job, speaker_source)
+	var/job = nttc ? nttc.retrieve_relevant_job(speaker_source, id_card, FALSE) : null
+	var/job_custom_name = nttc ? nttc.retrieve_relevant_job(speaker_source, id_card, TRUE) : null // so we getting both custom and non-custom
+	var/job_part = compose_job(speaker, raw_message, radio_freq, namepart, announcer, job, job_custom_name, speaker_source)
 	if (radio_freq && nttc && nttc.toggle_command_bold)
 		var/show_bold = job && (job in GLOB.nttc_highlight_jobs)
 		if (show_bold)
@@ -205,15 +206,15 @@ GLOBAL_LIST_INIT(freqtospan, list(
 /atom/movable/proc/compose_track_href(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	return ""
 
-// SS1984 EDIT START, DONT FORGET TO UPDATE SAME METHOD IN say_ai.dm IF MODIFY PARAMS!
-/atom/movable/proc/compose_job(atom/movable/speaker, raw_message, radio_freq, namepart, obj/machinery/announcement_system/announcer, job, speaker_source)
+// SS1984 EDIT START, DONT FORGET TO UPDATE SAME METHOD IN ai_say.dm IF MODIFY PARAMS!
+/atom/movable/proc/compose_job(atom/movable/speaker, raw_message, radio_freq, namepart, obj/machinery/announcement_system/announcer, job, job_custom_name, speaker_source)
 	if (!radio_freq || !announcer)
 		return "[namepart]"
 	var/datum/nttc_configuration/nttc = announcer ? announcer.nttc : null
 	if (!nttc) // very weird if it's not exist, as it built-in to announcer
 		return "[namepart]"
 
-	return nttc.compose_ntts_job(raw_message, namepart, announcer, job, speaker_source)
+	return nttc.compose_ntts_job(raw_message, namepart, announcer, job, job_custom_name, speaker_source)
 // SS1984 EDIT END
 
 /**

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -7,12 +7,12 @@
 		return "<a href='byond://?src=[REF(src)];track=[html_encode(namepart)]'>"
 	return ""
 
-/mob/living/silicon/compose_job(atom/movable/speaker, raw_message, radio_freq, namepart, obj/machinery/announcement_system/announcer, job, speaker_source) //SS1984 EDIT
+/mob/living/silicon/compose_job(atom/movable/speaker, raw_message, radio_freq, namepart, obj/machinery/announcement_system/announcer, job, job_custom_name, speaker_source) //SS1984 EDIT
 	//Also includes the </a> for AI hrefs, for convenience.
 	if(!HAS_TRAIT(src, TRAIT_CAN_GET_AI_TRACKING_MESSAGE))
 	//SS1984 EDIT START
 		return "[namepart]" + "</a>"
-	var/retrieved_msg = ..(speaker, raw_message, radio_freq, namepart, announcer, job, speaker_source)
+	var/retrieved_msg = ..(speaker, raw_message, radio_freq, namepart, announcer, job, job_custom_name, speaker_source)
 	if (retrieved_msg == "[namepart]")
 		retrieved_msg += " ([speaker.GetJob()])" // smart enough to get job bypassing disabled settings at telecomms
 	return retrieved_msg + "</a>"

--- a/modular_ss220/modules/enhanced_messaging/code/nttc_configuration.dm
+++ b/modular_ss220/modules/enhanced_messaging/code/nttc_configuration.dm
@@ -10,10 +10,19 @@
 /datum/nttc_configuration/proc/retrieve_relevant_job(speaker_source, obj/item/card/id/id_card, get_custom_jobname)
 	var/job_at_card
 	if (id_card)
-		if (!get_custom_jobname && id_card.trim && id_card.trim.assignment)
-			job_at_card = id_card.trim.assignment
+		if (istype(id_card, /obj/item/card/id/advanced/chameleon))
+			// chameleon-card case
+			var/obj/item/card/id/advanced/chameleon/chameleon_card = id_card
+			if (!get_custom_jobname && chameleon_card.trim_assignment_override)
+				job_at_card = chameleon_card.trim_assignment_override
+			else
+				job_at_card = chameleon_card.assignment
 		else
-			job_at_card = id_card.assignment
+			// non-chameleon case
+			if (!get_custom_jobname && id_card.trim && id_card.trim.assignment)
+				job_at_card = id_card.trim.assignment
+			else
+				job_at_card = id_card.assignment
 	if (job_at_card) // could be null at this moment
 		if (!ishuman(speaker_source))
 			return job_at_card

--- a/modular_ss220/modules/enhanced_messaging/code/nttc_configuration.dm
+++ b/modular_ss220/modules/enhanced_messaging/code/nttc_configuration.dm
@@ -7,10 +7,10 @@
 	var/toggle_name_color = TRUE
 	var/toggle_command_bold = TRUE
 
-/datum/nttc_configuration/proc/retrieve_relevant_job(speaker_source, obj/item/card/id/id_card)
+/datum/nttc_configuration/proc/retrieve_relevant_job(speaker_source, obj/item/card/id/id_card, get_custom_jobname)
 	var/job_at_card
 	if (id_card)
-		if (id_card.trim && id_card.trim.assignment)
+		if (!get_custom_jobname && id_card.trim && id_card.trim.assignment)
 			job_at_card = id_card.trim.assignment
 		else
 			job_at_card = id_card.assignment
@@ -38,7 +38,7 @@
 			return "Bot"
 	return "No id"
 
-/datum/nttc_configuration/proc/compose_ntts_job(raw_message, namepart, obj/machinery/announcement_system/announcer, job, speaker_source)
+/datum/nttc_configuration/proc/compose_ntts_job(raw_message, namepart, obj/machinery/announcement_system/announcer, job, job_custom_name, speaker_source)
 	var/job_class
 	var/name_with_job
 
@@ -58,11 +58,15 @@
 	if (toggle_name_color)
 		namepart = "<span class='[job_class]'>[namepart]</span>"
 
+	var/job_span = job
 	if (toggle_jobs)
 		if (toggle_job_color)
-			job = "<span class='[job_class]'>[job]</span>"
+			if (job_custom_name)
+				job_span = "<span class='[job_class]'>[job_custom_name]</span>"
+			else
+				job_span = "<span class='[job_class]'>[job]</span>"
 
-		var/message_format = list("JOB" = job, "NAME" = namepart)
+		var/message_format = list("JOB" = job_span, "NAME" = namepart)
 		var/compiled_message = announcer.compile_config_message(/datum/aas_config_entry/nttc_job_indicator_type, message_format, raw_message)
 		if (toggle_job_color) // to color also brackets or other things
 			name_with_job = "<span class='[job_class]'>[compiled_message]</span>"


### PR DESCRIPTION
## Changelog

:cl:
fix: NTTC now works based on speaker zlevel instead of "hearer" zlevel (as ghost in centcomm now you properly see nttc from station)
fix: NTTC chameleon card now should properly work instead of "Unknown"
qol: NTTC now shows custom role (if exist) instead of default
/:cl:
