### PR TITLE
qol: extended navigation

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -594,11 +594,13 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/landmark/navigate_destination/LateInitialize()
-	if(!location)
-		var/obj/machinery/door/airlock/A = locate(/obj/machinery/door/airlock) in loc
-		location = A ? format_text(A.name) : get_area_name(src, format_text = TRUE)
+	// SS1984 REMOVAL START, look at modular_navigation
+	// if(!location)
+	// 	var/obj/machinery/door/airlock/A = locate(/obj/machinery/door/airlock) in loc
+	// 	location = A ? format_text(A.name) : get_area_name(src, format_text = TRUE)
 
-	GLOB.navigate_destinations[loc] = location
+	// GLOB.navigate_destinations[loc] = location
+	// SS1984 REMOVAL END
 
 	qdel(src)
 

--- a/modular_ss220/modules/modular_navigation/modular_navigation.dm
+++ b/modular_ss220/modules/modular_navigation/modular_navigation.dm
@@ -1,0 +1,14 @@
+SUBSYSTEM_DEF(extended_navigation)
+	name = "Extended Navigation"
+	flags = SS_NO_FIRE
+	dependencies = list(/datum/controller/subsystem/machines, /datum/controller/subsystem/atoms)
+
+/datum/controller/subsystem/extended_navigation/Initialize() // god bless, contractor now can find where is BRIG MAINTENANCE...
+	for(var/obj/machinery/power/apc/current_apc as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/apc))
+		if(!SSmapping.level_trait(current_apc.z, ZTRAIT_STATION)) // no paths for lavalend
+			continue
+		var/area/apc_area = current_apc.area
+		var/area_name = get_area_name(apc_area, format_text = TRUE)
+		GLOB.navigate_destinations[current_apc.loc] = area_name // so we bind it to apc location (easier for engineers btw)
+
+	return SS_INIT_SUCCESS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9219,4 +9219,5 @@
 #include "modular_ss220\modules\add_memory\mob.dm"
 #include "modular_ss220\modules\add_memory\general_custom_memory.dm"
 #include "modular_ss220\modules\add_memory\mind.dm"
+#include "modular_ss220\modules\modular_navigation\modular_navigation.dm"
 // END_INCLUDE


### PR DESCRIPTION
Он нашел BRIG MAINTENANCE...

## Changelog

:cl:
qol: Navigate now shows you path even if you don't have access
qol: Navigation max range increased to 255 (whole station zlevel)
qol: Navigate now shows all APC areas on station (Fore Primary Hallway, Robotics, Ordnance Lab, Xenobiology Maintenance and so on), instead of only predefined landmarks (like Research). Finally, he found Brig Maintenance.
/:cl:
