### PR TITLE
balance: Stunprod rebalance

### DIFF
--- a/modular_ss220/modules/balance-1984/baton.dm
+++ b/modular_ss220/modules/balance-1984/baton.dm
@@ -1,0 +1,3 @@
+/obj/item/melee/baton/security/cattleprod
+	knockdown_time = 1 // 1 tick, original 1.5 SECONDS (30 ticks)
+	w_class = WEIGHT_CLASS_NORMAL

--- a/modular_ss220/modules/balance-1984/baton.dm
+++ b/modular_ss220/modules/balance-1984/baton.dm
@@ -1,3 +1,3 @@
 /obj/item/melee/baton/security/cattleprod
-	knockdown_time = 1 // 1 tick, original 1.5 SECONDS (30 ticks)
+	knockdown_time = 1 // 1 tick, original 1.5 SECONDS (30 ticks), keep in mind that there's also time gap to get up after knockdown
 	w_class = WEIGHT_CLASS_NORMAL

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9225,4 +9225,5 @@
 #include "modular_ss220\modules\hacking_secure_storages\secure_storage_hacking_defines.dm"
 #include "modular_ss220\modules\hacking_secure_storages\secure_closets.dm"
 #include "modular_ss220\modules\hacking_secure_storages\secure.dm"
+#include "modular_ss220\modules\balance-1984\baton.dm"
 // END_INCLUDE


### PR DESCRIPTION
## Changelog

:cl:
balance: Stunprod knockdown time 1.5 seconds => 1 tick (~0.05 seconds). There's still time after knockdown received to get up regardless of knockdown_time)
balance: Stunprod size HUGE => NORMAL (can fit in backpack now)
/:cl: