### PR TITLE
balance: Taser rebalance

### DIFF
--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -14,6 +14,8 @@
 	VAR_PRIVATE/datum/weakref/beam_weakref
 	/// We need to track who was the ORIGINAL firer of the projectile specifically to ensure deflects work correctly
 	VAR_PRIVATE/datum/weakref/initial_firer_weakref
+	VAR_PROTECTED/apply_tase_effect = TRUE // SS1984 ADDITION, should tase status effect even be applied?
+	VAR_PROTECTED/show_beam_effect = TRUE // SS1984 ADDITION, should beam be shown once fired?
 
 /obj/projectile/energy/electrode/is_hostile_projectile()
 	return TRUE
@@ -24,13 +26,14 @@
 
 /obj/projectile/energy/electrode/fire(fire_angle, atom/direct_target)
 	if(firer)
-		beam_weakref = WEAKREF(firer.Beam(
-			BeamTarget = src,
-			icon = 'icons/effects/beam.dmi',
-			icon_state = "electrodes_nozap",
-			maxdistance = maximum_range + 1,
-			beam_type = /obj/effect/ebeam/electrodes_nozap,
-		))
+		if (show_beam_effect)
+			beam_weakref = WEAKREF(firer.Beam(
+				BeamTarget = src,
+				icon = 'icons/effects/beam.dmi',
+				icon_state = "electrodes_nozap",
+				maxdistance = maximum_range + 1,
+				beam_type = /obj/effect/ebeam/electrodes_nozap,
+			))
 		initial_firer_weakref = WEAKREF(firer)
 	return ..()
 
@@ -50,15 +53,16 @@
 
 	do_sparks(1, TRUE, src)
 	do_sparks(1, TRUE, fired_from)
-	target.apply_status_effect(
-		/*type = *//datum/status_effect/tased,
-		/*taser = */fired_from,
-		/*firer = */initial_firer_weakref?.resolve() || firer,
-		/*tase_stamina = */tase_stamina,
-		/*energy_drain = */STANDARD_CELL_CHARGE * 0.05,
-		/*electrode_name = */"\the [src]\s",
-		/*tase_range = */maximum_range + 1,
-	)
+	if (apply_tase_effect)
+		target.apply_status_effect(
+			/*type = *//datum/status_effect/tased,
+			/*taser = */fired_from,
+			/*firer = */initial_firer_weakref?.resolve() || firer,
+			/*tase_stamina = */tase_stamina,
+			/*energy_drain = */STANDARD_CELL_CHARGE * 0.05,
+			/*electrode_name = */"\the [src]\s",
+			/*tase_range = */maximum_range + 1,
+		)
 
 /obj/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
 	do_sparks(1, TRUE, src)

--- a/modular_ss220/modules/balance-1984/stun.dm
+++ b/modular_ss220/modules/balance-1984/stun.dm
@@ -1,0 +1,26 @@
+/obj/item/ammo_casing/energy/electrode
+	e_cost = LASER_SHOTS(15, STANDARD_CELL_CHARGE)
+	delay = 15
+
+/obj/item/ammo_casing/energy/electrode/old_electrode
+	e_cost = LASER_SHOTS(5, STANDARD_CELL_CHARGE)
+	projectile_type = /obj/item/ammo_casing/energy/electrode/old_electrode
+	delay = 0
+
+/obj/projectile/energy/electrode
+	apply_tase_effect = FALSE
+	show_beam_effect = FALSE
+	stamina = 15
+	range = 7
+	paralyze = 0.2 SECONDS // Kind of microstun
+	stutter = 8 SECONDS // Weaker than stunslug
+	jitter = 30 SECONDS // Weaker than stunslug
+
+/obj/projectile/energy/electrode/old_electrode
+	apply_tase_effect = TRUE
+	show_beam_effect = TRUE
+	stamina = 0 // handled by tase effect
+	range = 5
+	paralyze = 0 SECONDS // all that stuff handled by tase effect
+	stutter = 0 SECONDS
+	jitter = 0 SECONDS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9226,4 +9226,5 @@
 #include "modular_ss220\modules\hacking_secure_storages\secure_closets.dm"
 #include "modular_ss220\modules\hacking_secure_storages\secure.dm"
 #include "modular_ss220\modules\balance-1984\baton.dm"
+#include "modular_ss220\modules\balance-1984\stun.dm"
 // END_INCLUDE


### PR DESCRIPTION
## Changelog

:cl:
balance: Taser no longer apply tased status effect (no slowdown)
balance: Taser no longer drain cell energy and stamina after hit target
balance: Taser stamina damage 35 => 15
balance: Taser delay between shots 0 => 15 ticks (~0.75 seconds)
balance: Taser range 5 => 7
balance: Taser paralyze 0 => 0.2 seconds (kind of microstun or ranged disarm)
balance: Taser energy cost reduced, 5 => 15 shots with default battery
del: Taser no longer shows visual beam effect (by default)
/:cl:
