### PR TITLE
add: autolathe to several departments

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -6396,6 +6396,10 @@
 	},
 /obj/item/book/manual/wiki/research_and_development,
 /obj/item/toy/figure/scientist,
+/obj/item/stack/sheet/iron/ten,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
 /turf/open/floor/iron,
 /area/station/science/lab)
 "bCc" = (
@@ -7566,9 +7570,8 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "bPj" = (
-/obj/machinery/rnd/production/techfab/department/cargo,
-/obj/effect/turf_decal/stripes/box,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bPv" = (
@@ -14625,6 +14628,19 @@
 "dzw" = (
 /turf/closed/wall/r_wall,
 /area/station/security/brig)
+"dzP" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "rndlab1";
+	name = "Research and Development Shutter"
+	},
+/obj/machinery/autolathe,
+/obj/machinery/door/window/left/directional/north{
+	req_access = list("science");
+	name = "Research Autolathe"
+	},
+/turf/open/floor/plating,
+/area/station/science/lab)
 "dzQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/massdriver_ordnance,
@@ -22277,6 +22293,7 @@
 	name = "Research Lab Desk";
 	req_access = list("science")
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "fwi" = (
@@ -42080,6 +42097,15 @@
 	dir = 4
 	},
 /area/station/commons/fitness/recreation)
+"kpg" = (
+/obj/machinery/door/window/left/directional/south{
+	req_access = list("cargo");
+	name = "Cargo Autolathe"
+	},
+/obj/machinery/autolathe,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "kpj" = (
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
@@ -46559,6 +46585,7 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/autolathe/hacked,
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "lyx" = (
@@ -50544,6 +50571,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/autolathe,
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -61023,6 +61051,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/iron/ten,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "phX" = (
@@ -74501,6 +74534,11 @@
 	},
 /obj/structure/sign/warning/engine_safety/directional/south,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/iron/ten,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "svc" = (
@@ -81760,7 +81798,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "ujD" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 8
 	},
@@ -132956,7 +132993,7 @@ uwi
 xVd
 bwE
 lmC
-qlp
+dzP
 yiE
 veR
 hnq
@@ -138551,7 +138588,7 @@ hqK
 jPk
 rve
 djt
-pas
+kpg
 kUn
 djq
 qQE

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5342,7 +5342,6 @@
 /area/station/hallway/secondary/entry)
 "bvr" = (
 /obj/machinery/light_switch/directional/west,
-/obj/machinery/autolathe,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bvw" = (
@@ -7604,11 +7603,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "cah" = (
-/obj/machinery/status_display/supply{
-	pixel_x = -32
+/obj/machinery/autolathe,
+/obj/machinery/door/window/left/directional/east{
+	name = "Cargo Autolathe";
+	req_access = list("cargo")
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/cargo/office)
 "cax" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -9752,6 +9754,11 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/iron/ten,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
 /turf/open/floor/iron/smooth_edge,
 /area/station/security/lockers)
 "cFr" = (
@@ -28781,6 +28788,7 @@
 /area/station/engineering/atmos)
 "igB" = (
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/autolathe/hacked,
 /turf/open/floor/glass,
 /area/station/security/lockers)
 "igG" = (
@@ -59375,6 +59383,10 @@
 	pixel_x = -4;
 	pixel_y = -7
 	},
+/obj/item/stack/sheet/iron/ten,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -75839,6 +75851,19 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"vzA" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "rnd";
+	name = "Research Lab Shutters"
+	},
+/obj/machinery/autolathe,
+/obj/machinery/door/window/right/directional/north{
+	req_access = list("science");
+	name = "Research Autolathe"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "vzD" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
@@ -81869,6 +81894,10 @@
 /obj/item/multitool{
 	pixel_x = 8
 	},
+/obj/item/stack/sheet/iron/ten,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "xpw" = (
@@ -82686,6 +82715,7 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/entry)
 "xAn" = (
+/obj/machinery/autolathe,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "xAs" = (
@@ -239245,7 +239275,7 @@ uuP
 aGF
 uuP
 gam
-qQo
+cah
 lmv
 uuP
 tue
@@ -239502,7 +239532,7 @@ vlL
 qxQ
 eBe
 hnC
-cah
+qmi
 aSh
 ycQ
 nZh
@@ -263399,7 +263429,7 @@ eKl
 pxL
 lso
 hDb
-qWn
+vzA
 xZA
 dVt
 gHY

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1059,11 +1059,16 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "asT" = (
-/obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/machinery/autolathe,
+/obj/machinery/door/window/left/directional/east{
+	name = "Cargo Autolathe";
+	req_access = list("cargo")
+	},
+/turf/open/floor/iron,
 /area/station/cargo/lobby)
 "atf" = (
 /obj/structure/table/glass,
@@ -2829,6 +2834,10 @@
 /obj/item/folder/yellow{
 	pixel_y = 1;
 	pixel_x = 2
+	},
+/obj/item/stack/sheet/iron/ten,
+/obj/item/stack/sheet/glass{
+	amount = 10
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
@@ -6861,6 +6870,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
+/obj/machinery/autolathe/hacked,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "cvv" = (
@@ -28602,6 +28612,10 @@
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/sheet/iron/ten,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "jRZ" = (
@@ -30751,6 +30765,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"kDQ" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "rndlab2";
+	name = "Secondary Research and Development Shutter"
+	},
+/obj/machinery/autolathe,
+/obj/machinery/door/window/right/directional/west{
+	req_access = list("science");
+	name = "Research Autolathe"
+	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/plating,
+/area/station/science/lab)
 "kDS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36700,6 +36728,10 @@
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/item/stack/sheet/iron/ten,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "mMl" = (
@@ -52804,7 +52836,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/autolathe,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "smG" = (
@@ -54087,6 +54118,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/autolathe,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "sKJ" = (
@@ -100941,7 +100973,7 @@ uCq
 mvR
 dyw
 mJT
-dyw
+kDQ
 dyw
 mvR
 kFC

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -9363,6 +9363,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/autolathe,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cgX" = (
@@ -14687,6 +14688,7 @@
 /area/station/service/library)
 "dYe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/autolathe/hacked,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "dYm" = (
@@ -20331,6 +20333,19 @@
 /obj/structure/ladder,
 /turf/open/openspace/airless,
 /area/station/asteroid)
+"gfE" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Research and Development Shutter";
+	id = "rndlab1"
+	},
+/obj/machinery/autolathe,
+/obj/machinery/door/window/right/directional/north{
+	name = "Research Autolathe";
+	req_access = list("science")
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/plating,
+/area/station/science/lab)
 "gfK" = (
 /turf/closed/wall/r_wall,
 /area/station/security/execution/education)
@@ -31233,6 +31248,15 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel/monastery)
+"kcd" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/autolathe,
+/obj/machinery/door/window/left/directional/south{
+	req_access = list("cargo");
+	name = "Cargo Autolathe"
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "kce" = (
 /obj/effect/turf_decal/tile/neutral/tram,
 /obj/effect/spawner/random{
@@ -31825,7 +31849,6 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "kkq" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
@@ -32348,6 +32371,10 @@
 	pixel_x = -6;
 	pixel_y = 10
 	},
+/obj/item/stack/sheet/iron/ten,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ktb" = (
@@ -32591,6 +32618,10 @@
 /obj/machinery/recharger,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/item/stack/sheet/iron/ten,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "kzq" = (
@@ -41558,6 +41589,10 @@
 /obj/item/flatpack{
 	board = /obj/item/circuitboard/machine/flatpacker
 	},
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/sheet/iron/ten,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "nDX" = (
@@ -182656,7 +182691,7 @@ cwG
 sFc
 cwG
 ccj
-vYl
+kcd
 tRT
 cbH
 kMc
@@ -183193,7 +183228,7 @@ aHQ
 aIv
 aHQ
 nUy
-rHj
+gfE
 aJG
 uOx
 aKA


### PR DESCRIPTION
Добавляет автолаты на карты в Бриг, РнД, Инженерный отделы. Перемещен автолат Карго. Окна для доступа к автолатам РнД и Карго требуют соответствующих доступов, но могут быть открыты для свободного доступа. Автолат в СБ по умолчанию взломан. Также добавлено по 10 железа и стекла неподалеку от автолатов на столах

# Как это выглядит:

## Дельта

![delta_cargo](https://github.com/user-attachments/assets/03042956-7931-49af-ae57-257861497ac6)
![delta_engi](https://github.com/user-attachments/assets/25992e67-b33e-48b4-b183-d004f6cd2a36)
![delta_rnd](https://github.com/user-attachments/assets/0624bda4-1e96-45dc-bf02-ebbbb73c37dd)
![delta_sec](https://github.com/user-attachments/assets/83a3f463-0e99-4444-9b24-da851da7facf)

## Мета

![meta_cargo](https://github.com/user-attachments/assets/7f48e3e1-6fb2-4976-92e9-d458ffc9fb3a)
![meta_engi](https://github.com/user-attachments/assets/47b85943-1eac-4ecf-bc76-dea08b5202fc)
![meta_rnd](https://github.com/user-attachments/assets/0a83f631-1f37-4de6-a341-56d0a49e9aff)
![meta_sec](https://github.com/user-attachments/assets/dd205008-5df3-4cb3-8a0d-ebd2950ad317)

## Айсбокс

![icebox_cargo](https://github.com/user-attachments/assets/315168c2-0844-4ba8-915d-3401be3b64c5)
![icebox_engi](https://github.com/user-attachments/assets/b6cafa07-6df2-4aa4-9668-1b5653d1606c)
![icebox_rnd](https://github.com/user-attachments/assets/0a4fd4e0-f7f6-4ca9-b0aa-8d38986e5401)
![icebox_sec](https://github.com/user-attachments/assets/eb462da7-14c1-43d6-b7e5-1146d67d7bb6)

## Трам

![tram_cargo](https://github.com/user-attachments/assets/4dc10ab2-ce91-4f6a-8d90-85513383491a)
![tram_engi](https://github.com/user-attachments/assets/dc1b716b-d2a0-49d4-b6d8-38f8a28cdb3a)
![tram_rnd](https://github.com/user-attachments/assets/0e3edd1f-06af-4aa6-aab5-24967b38848f)
![tram_sec](https://github.com/user-attachments/assets/e2d089de-61f6-4bf0-9f05-2897a00e2e82)

### P.S.
Если кто-то сделает аналогичные изменения на других картах, буду признателен. Пока не понятно как это будет мержиться с upstream, поэтому только половина карт.

## Changelog

:cl:
map: Added autolathes to engineering, brig, research at maps: Delta, Meta, Tram, Icebox
map: Added 10 glass and 10 iron near added autolathes
map: Moved cargo autolathe, so it can be accesed if cargo open window to it
map: Security autolathe is hacked by default
/:cl: