### PR TITLE
config: disable shuttle max votes cap

### DIFF
--- a/config/nova/config_nova.txt
+++ b/config/nova/config_nova.txt
@@ -62,7 +62,7 @@ VOTE_AUTOTRANSFER_INTERVAL 18000
 ## autovote maximum votes until automatic transfer call. (default 4)
 ## Set to 0 to force automatic crew transfer after the 'vote_autotransfer_initial' elapsed.
 ## Set to -1 to disable the maximum votes cap.
-VOTE_AUTOTRANSFER_MAXIMUM 4
+VOTE_AUTOTRANSFER_MAXIMUM -1
 
 ## Policy for what people remember after dying and being brought back to life
 BLACKOUTPOLICY You remember nothing after you've blacked out and you do not remember who or what events killed you, however, you can have faint recollection of what led up to it.


### PR DESCRIPTION
## Changelog

:cl:
config: Disabled autotransfer vote cap. Shuttle no longer auto-calls after 4 shuttle votes even when selected continue playing
/:cl: