### PR TITLE
qol: Select/Deselect all access button in ID computer

### DIFF
--- a/modular_ss220/modules/access_console_buttons/card.dm
+++ b/modular_ss220/modules/access_console_buttons/card.dm
@@ -1,0 +1,39 @@
+/datum/computer_file/program/card_mod/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if (.)
+		return .
+	var/mob/user = usr
+	var/obj/item/card/id/inserted_auth_card = computer.computer_id_slot
+	switch (action)
+		if("select_all") // сould be optimized if we modify the way we getting data, but is someone really care for such function?
+			var/list/params_received = params["accesses"]
+			if(!computer || !authenticated_card || !inserted_auth_card || !params_received || params_received.len < 1)
+				return TRUE
+			playsound(computer, SFX_TERMINAL_TYPE, 50, FALSE)
+			for(var/department in params_received) // UI mess here we go
+				var/list/accesses_department = department["accesses"]
+				for(var/access_data in accesses_department)
+					var/access_type = access_data["ref"]
+					if (access_type in inserted_auth_card.access)
+						continue
+					if (!inserted_auth_card.add_access(list(access_type), "All"))
+						to_chat(usr, span_notice("ID error: ID card rejected your attempted access modification."))
+						LOG_ID_ACCESS_CHANGE(user, inserted_auth_card, "failed to add [SSid_access.get_access_desc(access_type)]")
+						continue
+					if(access_type in ACCESS_ALERT_ADMINS)
+						message_admins("[ADMIN_LOOKUPFLW(user)] just added [SSid_access.get_access_desc(access_type)] to an ID card [ADMIN_VV(inserted_auth_card)] [(inserted_auth_card.registered_name) ? "belonging to [inserted_auth_card.registered_name]." : "with no registered name."]")
+					LOG_ID_ACCESS_CHANGE(user, inserted_auth_card, "added [SSid_access.get_access_desc(access_type)]")
+			return TRUE
+		if ("deselect_all")
+			var/list/params_received = params["accesses"]
+			if(!computer || !authenticated_card || !inserted_auth_card || !params_received || params_received.len < 1)
+				return TRUE
+			playsound(computer, SFX_TERMINAL_TYPE, 50, FALSE)
+			for(var/department in params_received) // UI mess here we go
+				var/list/accesses_department = department["accesses"]
+				for(var/access_data in accesses_department)
+					var/access_type = access_data["ref"]
+					if(access_type in inserted_auth_card.access)
+						inserted_auth_card.remove_access(list(access_type))
+						LOG_ID_ACCESS_CHANGE(user, inserted_auth_card, "removed [SSid_access.get_access_desc(access_type)]")
+			return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9240,4 +9240,5 @@
 #include "modular_ss220\modules\security_vouchers\security_voucher.dm"
 #include "modular_ss220\modules\infinite_access_slots\infinite_access_slots_config.dm"
 #include "modular_ss220\modules\infinite_access_slots\cards_ids.dm"
+#include "modular_ss220\modules\access_console_buttons\card.dm"
 // END_INCLUDE

--- a/tgui/packages/tgui/interfaces/ChameleonCard.jsx
+++ b/tgui/packages/tgui/interfaces/ChameleonCard.jsx
@@ -62,6 +62,13 @@ export const ChameleonCard = (props) => {
               access_wildcard: wildcard,
             })
           }
+          // SS1984 ADDITION START
+          extraActions={(action_name, accesses_list) =>
+            act(action_name, {
+              accesses: accesses_list,
+            })
+          }
+          // SS1984 ADDITION END
         />
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/NtosCard.tsx
+++ b/tgui/packages/tgui/interfaces/NtosCard.tsx
@@ -128,6 +128,13 @@ export const NtosCardContent = (props) => {
                     access_wildcard: wildcard,
                   })
                 }
+                // SS1984 ADDITION START
+                extraActions={(action_name, accesses_list) =>
+                  act(action_name, {
+                    accesses: accesses_list,
+                  })
+                }
+                // SS1984 ADDITION END
               />
             </Box>
           )}

--- a/tgui/packages/tgui/interfaces/common/AccessList.jsx
+++ b/tgui/packages/tgui/interfaces/common/AccessList.jsx
@@ -15,6 +15,7 @@ export const AccessList = (props) => {
     wildcardFlags = {},
     extraButtons,
     showBasic,
+    extraActions, // SS1984 ADDITION
   } = props;
 
   const [wildcardTab, setWildcardTab] = useSharedState(
@@ -108,6 +109,10 @@ export const AccessList = (props) => {
             showBasic={showBasic}
             basicUsed={selectedTrimAccess.length}
             basicMax={trimAccess.length}
+            // SS1984 ADDITION START
+            extraActions={extraActions}
+            accesses={parsedRegions}
+            // SS1984 ADDITION END
           />
         </Flex.Item>
         <Flex.Item>
@@ -131,7 +136,7 @@ export const AccessList = (props) => {
 };
 
 export const FormatWildcards = (props) => {
-  const { wildcardSlots = {}, showBasic, basicUsed = 0, basicMax = 0 } = props;
+  const { wildcardSlots = {}, showBasic, basicUsed = 0, basicMax = 0, extraActions, accesses } = props; // SS1984 ADDITION, added: extraActions, accesses
 
   const [wildcardTab, setWildcardTab] = useSharedState(
     'wildcardSelected',
@@ -148,7 +153,7 @@ export const FormatWildcards = (props) => {
   }
 
   return (
-    <Stack align="horizontal"> {/* SS1984 ADDITION*/}
+    <Stack fill horizontal> {/* SS1984 ADDITION*/}
       <Tabs>
         {showBasic && (
           <Tabs.Tab
@@ -183,16 +188,25 @@ export const FormatWildcards = (props) => {
           );
         })}
       </Tabs>
+      {/* SS1984 ADDITION START */}
       <Button
+        onClick={() =>
+          extraActions("select_all", accesses)
+        }
+        height="80%"
         icon="check">
           Select All
       </Button>
       <Button.Confirm
+        onClick={() =>
+          extraActions("deselect_all", accesses)
+        }
+        height="80%"
         confirmContent="Are you sure?"
         icon="close">
           Deselect All
       </Button.Confirm>
-      {/* onClick={() => act('flee')} */ }
+      {/* SS1984 ADDITION END */ }
     </Stack> // SS1984 ADDITION
   );
 };

--- a/tgui/packages/tgui/interfaces/common/AccessList.jsx
+++ b/tgui/packages/tgui/interfaces/common/AccessList.jsx
@@ -1,5 +1,5 @@
 import { sortBy } from 'common/collections';
-import { Button, Flex, Section, Tabs } from 'tgui-core/components';
+import { Button, Flex, Section, Stack, Tabs } from 'tgui-core/components'; // SS1984 ADDITION: Added "Stack" import
 
 import { useSharedState } from '../../backend';
 
@@ -148,40 +148,52 @@ export const FormatWildcards = (props) => {
   }
 
   return (
-    <Tabs>
-      {showBasic && (
-        <Tabs.Tab
-          selected={selectedWildcard === 'None'}
-          onClick={() => setWildcardTab('None')}
-        >
-          Trim:
-          <br />
-          {basicUsed + '/' + basicMax}
-        </Tabs.Tab>
-      )}
-
-      {Object.keys(wildcardSlots).map((wildcard) => {
-        const wcObj = wildcardSlots[wildcard];
-        let wcLimit = wcObj.limit;
-        const wcUsage = wcObj.usage.length;
-        const wcLeft = wcLimit - wcUsage;
-        if (wcLeft < 0) {
-          wcLimit = '∞';
-        }
-        const wcLeftStr = `${wcUsage}/${wcLimit}`;
-        return (
+    <Stack align="horizontal"> {/* SS1984 ADDITION*/}
+      <Tabs>
+        {showBasic && (
           <Tabs.Tab
-            key={wildcard}
-            selected={selectedWildcard === wildcard}
-            onClick={() => setWildcardTab(wildcard)}
+            selected={selectedWildcard === 'None'}
+            onClick={() => setWildcardTab('None')}
           >
-            {wildcard + ':'}
+            Trim:
             <br />
-            {wcLeftStr}
+            {basicUsed + '/' + basicMax}
           </Tabs.Tab>
-        );
-      })}
-    </Tabs>
+        )}
+
+        {Object.keys(wildcardSlots).map((wildcard) => {
+          const wcObj = wildcardSlots[wildcard];
+          let wcLimit = wcObj.limit;
+          const wcUsage = wcObj.usage.length;
+          const wcLeft = wcLimit - wcUsage;
+          if (wcLeft < 0) {
+            wcLimit = '∞';
+          }
+          const wcLeftStr = `${wcUsage}/${wcLimit}`;
+          return (
+            <Tabs.Tab
+              key={wildcard}
+              selected={selectedWildcard === wildcard}
+              onClick={() => setWildcardTab(wildcard)}
+            >
+              {wildcard + ':'}
+              <br />
+              {wcLeftStr}
+            </Tabs.Tab>
+          );
+        })}
+      </Tabs>
+      <Button
+        icon="check">
+          Select All
+      </Button>
+      <Button.Confirm
+        confirmContent="Are you sure?"
+        icon="close">
+          Deselect All
+      </Button.Confirm>
+      {/* onClick={() => act('flee')} */ }
+    </Stack> // SS1984 ADDITION
   );
 };
 


### PR DESCRIPTION
## Changelog

:cl:
qol: Select/Deselect all access buttons added to ID computer. Now you can select/deselect all acceses visible in console at Trim/All tabs (not by department). To get full access, you need to use "select all" button at BOTH "Trim" and "All" tabs
/:cl:
