### PR TITLE
admin: disable infinity access slots debug button

### DIFF
--- a/modular_ss220/modules/infinite_access_slots/id_access.dm
+++ b/modular_ss220/modules/infinite_access_slots/id_access.dm
@@ -1,0 +1,26 @@
+/datum/controller/subsystem/id_access/Initialize()
+	. = ..() //lets load it first for extra i/o safety in case of runtime later
+	if(!fexists(PATH_TO_WILDCARD_SETTING_CACHE))
+		return .
+
+	var/json = file(PATH_TO_WILDCARD_SETTING_CACHE)
+	if(!json)
+		return .
+
+	json = file2text(json)
+	if(!json)
+		return .
+
+	json = json_decode(json)
+	if(!json)
+		return .
+
+	if (json["disable_infinity_wildcard"])
+		CONFIG_SET(flag/infinite_access_slots, FALSE)
+		log_world("flag infinite_access_slots set to FALSE by cached [PATH_TO_WILDCARD_SETTING_CACHE] file")
+		var/msg_constructed = "infinity wildcard access slots was disabled for this round (by admin at last round)"
+		message_admins(msg_constructed)
+		log_admin(msg_constructed)
+
+	fdel(PATH_TO_WILDCARD_SETTING_CACHE)
+	return .

--- a/modular_ss220/modules/infinite_access_slots/infinite_access_slots_config.dm
+++ b/modular_ss220/modules/infinite_access_slots/infinite_access_slots_config.dm
@@ -1,1 +1,2 @@
 /datum/config_entry/flag/infinite_access_slots
+	protection = CONFIG_ENTRY_LOCKED

--- a/modular_ss220/modules/infinite_access_slots/secrets.dm
+++ b/modular_ss220/modules/infinite_access_slots/secrets.dm
@@ -1,0 +1,48 @@
+#define PATH_TO_WILDCARD_SETTING_CACHE "data/infinity_wildcard_override.json"
+
+GLOBAL_VAR_INIT(SAVED_WILDCARD_SETTING_CACHE, FALSE)
+GLOBAL_PROTECT(SAVED_WILDCARD_SETTING_CACHE)
+
+/datum/secrets_menu/ui_data(mob/user)
+	. = ..()
+	var/data = .
+	if (!data)
+		data = list()
+
+	data["is_pregame"] = SSticker?.current_state <= GAME_STATE_PREGAME
+	if (SSticker?.current_state >= GAME_STATE_SETTING_UP)
+		data["is_infinity_wildcard_disabled"] = GLOB.SAVED_WILDCARD_SETTING_CACHE
+	else
+		data["is_infinity_wildcard_disabled"] = GLOB.SAVED_WILDCARD_SETTING_CACHE || !CONFIG_GET(flag/infinite_access_slots)
+	return data
+
+/datum/secrets_menu/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if (.)
+		return
+	if (action != "disable_infinity_wildcard" || GLOB.SAVED_WILDCARD_SETTING_CACHE)
+		return
+	if (!CONFIG_GET(flag/infinite_access_slots) && SSticker?.current_state <= GAME_STATE_PREGAME)
+		return
+	if(!check_rights(R_ADMIN))
+		return
+	var/game_state_pregame = SSticker?.current_state <= GAME_STATE_PREGAME
+	if (game_state_pregame) // for this round, still applicable
+		CONFIG_SET(flag/infinite_access_slots, FALSE)
+		var/msg_constructed = "[key_name(holder)] disabled infinity wildcard access slots for this round"
+		message_admins(msg_constructed)
+		log_admin(msg_constructed)
+		return
+	GLOB.SAVED_WILDCARD_SETTING_CACHE = TRUE // save for correct checks and avoid for excess i/o
+	var/msg_constructed_next = "[key_name(holder)] disabled infinity wildcard access slots for next round"
+	message_admins(msg_constructed_next)
+	log_admin(msg_constructed_next)
+	// save for next round
+	var/list/json_value = list()
+	json_value = list(
+		"disable_infinity_wildcard" = TRUE,
+	)
+	// If the file isn't removed text2file will just append.
+	if(fexists(PATH_TO_WILDCARD_SETTING_CACHE))
+		fdel(PATH_TO_WILDCARD_SETTING_CACHE)
+	text2file(json_encode(json_value), PATH_TO_WILDCARD_SETTING_CACHE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9242,4 +9242,6 @@
 #include "modular_ss220\modules\infinite_access_slots\infinite_access_slots_config.dm"
 #include "modular_ss220\modules\infinite_access_slots\cards_ids.dm"
 #include "modular_ss220\modules\access_console_buttons\card.dm"
+#include "modular_ss220\modules\infinite_access_slots\secrets.dm"
+#include "modular_ss220\modules\infinite_access_slots\id_access.dm"
 // END_INCLUDE

--- a/tgui/packages/tgui/interfaces/Secrets.jsx
+++ b/tgui/packages/tgui/interfaces/Secrets.jsx
@@ -42,10 +42,11 @@ const TAB2NAME = [
 
 const lineHeightNormal = 2.79;
 const buttonWidthNormal = 12.9;
-const lineHeightDebug = 6.09;
+const lineHeightDebug = 3.09; // SS1984 EDIT, original: 6.09
 
 const DebuggingTab = (props) => {
-  const { act } = useBackend();
+  const { act, data } = useBackend(); // SS1984 ADDITION, added data
+  const { is_pregame, is_infinity_wildcard_disabled } = data; // SS1984 ADDITION
   return (
     <Stack fill vertical>
       <Stack.Item>
@@ -78,6 +79,30 @@ const DebuggingTab = (props) => {
           onClick={() => act('infinite_sec')}
         />
       </Stack.Item>
+      { /* SS1984 ADDITION START */ }
+      <Stack.Item>
+        <Button
+          color="average"
+          disabled={is_infinity_wildcard_disabled}
+          lineHeight={lineHeightDebug}
+          icon={is_pregame ? "ellipsis-h" : "exclamation"}
+          fluid
+          onClick={() => act('disable_infinity_wildcard')}
+        >
+          <span>Disable infinity wildcard access override for </span>
+          {is_pregame ?
+          <span style={{ color: 'red' }}>
+            <b>THIS</b>
+          </span>
+          :
+          <span style={{ color: 'yellow' }}>
+            <b>NEXT</b>
+          </span>
+          }
+          <span> round </span>
+        </Button>
+      </Stack.Item>
+      { /* SS1984 ADDITION END */ }
     </Stack>
   );
 };


### PR DESCRIPTION
## Changelog

:cl:
admin: Added button at "Secrets" - "Debugging" tab to disable infinity access slots for this round (if not started yet) or next round (if round already started)
admin: Infinity access slots is config-locked now from VV. Use added button instead
admin: Debugging tab at "Secrets" reduced buttons vertical size
/:cl: