### PR TITLE
fix: Select All at ID computer fixes when not infinity slots

### DIFF
--- a/modular_ss220/modules/access_console_buttons/card.dm
+++ b/modular_ss220/modules/access_console_buttons/card.dm
@@ -9,6 +9,7 @@
 			var/list/params_received = params["accesses"]
 			if(!computer || !authenticated_card || !inserted_auth_card || !params_received || params_received.len < 1)
 				return TRUE
+			var/wildcardTab = params["selectedWildcard"]
 			playsound(computer, SFX_TERMINAL_TYPE, 50, FALSE)
 			for(var/department in params_received) // UI mess here we go
 				var/list/accesses_department = department["accesses"]
@@ -16,10 +17,8 @@
 					var/access_type = access_data["ref"]
 					if (access_type in inserted_auth_card.access)
 						continue
-					if (!inserted_auth_card.add_access(list(access_type), "All"))
-						to_chat(usr, span_notice("ID error: ID card rejected your attempted access modification."))
-						LOG_ID_ACCESS_CHANGE(user, inserted_auth_card, "failed to add [SSid_access.get_access_desc(access_type)]")
-						continue
+					if (!inserted_auth_card.add_access(list(access_type), wildcardTab))
+						continue // don't spam excess logs and errors to client
 					if(access_type in ACCESS_ALERT_ADMINS)
 						message_admins("[ADMIN_LOOKUPFLW(user)] just added [SSid_access.get_access_desc(access_type)] to an ID card [ADMIN_VV(inserted_auth_card)] [(inserted_auth_card.registered_name) ? "belonging to [inserted_auth_card.registered_name]." : "with no registered name."]")
 					LOG_ID_ACCESS_CHANGE(user, inserted_auth_card, "added [SSid_access.get_access_desc(access_type)]")

--- a/tgui/packages/tgui/interfaces/common/AccessList.jsx
+++ b/tgui/packages/tgui/interfaces/common/AccessList.jsx
@@ -191,7 +191,7 @@ export const FormatWildcards = (props) => {
       {/* SS1984 ADDITION START */}
       <Button
         onClick={() =>
-          extraActions("select_all", accesses)
+          extraActions("select_all", accesses, selectedWildcard)
         }
         height="80%"
         icon="check">
@@ -199,7 +199,7 @@ export const FormatWildcards = (props) => {
       </Button>
       <Button.Confirm
         onClick={() =>
-          extraActions("deselect_all", accesses)
+          extraActions("deselect_all", accesses, selectedWildcard)
         }
         height="80%"
         confirmContent="Are you sure?"


### PR DESCRIPTION
## Changelog

:cl:
fix: Select All button at ID computer is now should work correctly when infinity access slots is disabled
qol: Less chat and log spam on fail to add access using "Select All"
/:cl:
