### PR TITLE
fix: fix html &nbsp; and &ensp; where needed

### DIFF
--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -1,5 +1,5 @@
 /// Does 4 spaces. Used as a makeshift tabulator.
-#define FOURSPACES "&nbsp;&nbsp;&nbsp;&nbsp;"
+#define FOURSPACES "{'\u00A0'}{'\u00A0'}{'\u00A0'}{'\u00A0'}"
 
 /// Standard maptext
 /// Prepares a text to be used for maptext. Use this so it doesn't look hideous.

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -653,7 +653,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 	t = replacetext(t, regex("(?:\\r\\n?|\\n)", "g"), "<br>")
 
-	t = replacetext(t, "  ", "&nbsp;&nbsp;")
+	t = replacetext(t, "  ", "{'\u00A0'}{'\u00A0'}")
 
 	// Done
 

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -179,7 +179,7 @@
 			LAZYSET(language_icons, language, language_icon)
 		LAZYADD(prefixes, "\icon[language_icon]")
 
-	text = "[prefixes?.Join("&nbsp;")][text]"
+	text = "[prefixes?.Join("{'\u00A0'}")][text]"
 
 	// We dim italicized text to make it more distinguishable from regular text
 	var/tgt_color = extra_classes.Find("italics") ? target.chat_color_darkened : target.chat_color

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -983,7 +983,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 	return querys
 
 /proc/SDQL_testout(list/query_tree, indent = 0)
-	var/static/whitespace = "&nbsp;&nbsp;&nbsp; "
+	var/static/whitespace = "{'\u00A0'}{'\u00A0'}{'\u00A0'} "
 	var/spaces = ""
 	if(indent > 0)
 		for(var/i in 1 to indent)

--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -224,7 +224,7 @@ ADMIN_VERB(beaker_panel, R_SPAWN, "Spawn Reagent Container", "Spawn a reagent co
 
 					function addReagent(ul, reagentType, reagentName, amount)
 					{
-						$('<li class="reagent" data-type="'+reagentType+'">'+reagentName+'<div><input class="reagent" value="'+amount+'" />&nbsp;&nbsp;<button class="remove-reagent"><i class="far fa-trash-alt"></i>&nbsp;Remove</button></div></li>').insertBefore($(ul).children('li').last());
+						$('<li class="reagent" data-type="'+reagentType+'">'+reagentName+'<div><input class="reagent" value="'+amount+'" />{'\u00A0'}{'\u00A0'}<button class="remove-reagent"><i class="far fa-trash-alt"></i>{'\u00A0'}Remove</button></div></li>').insertBefore($(ul).children('li').last());
 					  $(ul).children('li').last().prev().find('button').click(function() { $(this).parents('li').remove(); });
 					}
 
@@ -259,7 +259,7 @@ ADMIN_VERB(beaker_panel, R_SPAWN, "Spawn Reagent Container", "Spawn a reagent co
 
 		<div class="width: 100%">
 		<button id="spawn-grenade">
-		<i class="fas fa-bomb"></i>&nbsp;Spawn grenade
+		<i class="fas fa-bomb"></i>{'\u00A0'}Spawn grenade
 		</button>
 			<label for="grenade-type">Grenade type: </label>
 		<select id="grenade-type">
@@ -285,23 +285,23 @@ ADMIN_VERB(beaker_panel, R_SPAWN, "Spawn Reagent Container", "Spawn a reagent co
 			<br />
 			<div>
 			<button class="spawn-container">
-			<i class="fas fa-cog"></i>&nbsp;Spawn
+			<i class="fas fa-cog"></i>{'\u00A0'}Spawn
 				</button>
-				&nbsp;&nbsp;&nbsp;
+				{'\u00A0'}{'\u00A0'}{'\u00A0'}
 				<button class="import-reagents">
-			<i class="fas fa-file-import"></i>&nbsp;Import
+			<i class="fas fa-file-import"></i>{'\u00A0'}Import
 				</button>
-				&nbsp;&nbsp;&nbsp;
+				{'\u00A0'}{'\u00A0'}{'\u00A0'}
 				<button class="export-reagents">
-			<i class="fas fa-file-export"></i>&nbsp;Export
+			<i class="fas fa-file-export"></i>{'\u00A0'}Export
 				</button>
 
 			</div>
 				<ul>
 				<li>
 
-					<select class="select-new-reagent"></select><div class="reagent-div"><input style="width: 50%" type="text" name="newreagent" value="40" />&nbsp;&nbsp;<button class="add-reagent">
-				<i class="fas fa-plus"></i>&nbsp;Add
+					<select class="select-new-reagent"></select><div class="reagent-div"><input style="width: 50%" type="text" name="newreagent" value="40" />{'\u00A0'}{'\u00A0'}<button class="add-reagent">
+				<i class="fas fa-plus"></i>{'\u00A0'}Add
 				</button>
 
 				</div>

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -37,14 +37,14 @@ ADMIN_VERB(radio_report, R_DEBUG, "Radio Report", "Shows a report of all radio d
 		output += "<b>Freq: [fq]</b><br>"
 		var/datum/radio_frequency/fqs = SSradio.frequencies[fq]
 		if (!fqs)
-			output += "&nbsp;&nbsp;<b>ERROR</b><br>"
+			output += "{'\u00A0'}{'\u00A0'}<b>ERROR</b><br>"
 			continue
 		for (var/filter in fqs.devices)
 			var/list/filtered = fqs.devices[filter]
 			if (!filtered)
-				output += "&nbsp;&nbsp;[filter]: ERROR<br>"
+				output += "{'\u00A0'}{'\u00A0'}[filter]: ERROR<br>"
 				continue
-			output += "&nbsp;&nbsp;[filter]: [filtered.len]<br>"
+			output += "{'\u00A0'}{'\u00A0'}[filter]: [filtered.len]<br>"
 			for(var/datum/weakref/device_ref as anything in filtered)
 				var/atom/device = device_ref.resolve()
 				if(!device)
@@ -52,9 +52,9 @@ ADMIN_VERB(radio_report, R_DEBUG, "Radio Report", "Shows a report of all radio d
 					continue
 				if (istype(device, /atom))
 					var/atom/A = device
-					output += "&nbsp;&nbsp;&nbsp;&nbsp;[device] ([AREACOORD(A)])<br>"
+					output += "{'\u00A0'}{'\u00A0'}{'\u00A0'}{'\u00A0'}[device] ([AREACOORD(A)])<br>"
 				else
-					output += "&nbsp;&nbsp;&nbsp;&nbsp;[device]<br>"
+					output += "{'\u00A0'}{'\u00A0'}{'\u00A0'}{'\u00A0'}[device]<br>"
 
 	var/datum/browser/browser = new(user, "radioreport", "Radio Logs", 400, 440)
 	browser.set_content(output)

--- a/code/modules/admin/view_variables/debug_variables.dm
+++ b/code/modules/admin/view_variables/debug_variables.dm
@@ -117,13 +117,13 @@
 
 /matrix/debug_variable_value(name, level, datum/owner, sanitize, display_flags)
 	return {"<span class='value'>
-			<table class='matrixbrak'><tbody><tr><td class='lbrak'>&nbsp;</td><td>
+			<table class='matrixbrak'><tbody><tr><td class='lbrak'>{'\u00A0'}</td><td>
 			<table class='matrix'>
 			<tbody>
 				<tr><td>[a]</td><td>[d]</td><td>0</td></tr>
 				<tr><td>[b]</td><td>[e]</td><td>0</td></tr>
 				<tr><td>[c]</td><td>[f]</td><td>1</td></tr>
 			</tbody>
-			</table></td><td class='rbrak'>&nbsp;</td></tr></tbody></table></span>"} //TODO link to modify_transform wrapper for all matrices
+			</table></td><td class='rbrak'>{'\u00A0'}</td></tr></tbody></table></span>"} //TODO link to modify_transform wrapper for all matrices
 
 #undef VV_HTML_ENCODE

--- a/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
+++ b/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
@@ -172,7 +172,7 @@ export const AmmunitionsTab = (props) => {
             <br />
             <br />
             These modules are <b>reusable</b> and can have their license points
-            recharged with <b>authenticators</b>, which are&nbsp;
+            recharged with <b>authenticators</b>, which are{'\u00A0'}
             <b>much cheaper</b> than individual modules. These can be purchased
             from Cargo or printed from techfabs with the proper technology
             researched.

--- a/tgui/packages/tgui/interfaces/AntagInfoAssaultops.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoAssaultops.tsx
@@ -64,7 +64,7 @@ export const AntagInfoAssaultops = (props) => {
             <Section>
               <Stack.Item grow={1} align="center">
                 <Box fontSize={0.8} textAlign="right">
-                  GoldeneEye Defnet &nbsp;
+                  GoldeneEye Defnet {'\u00A0'}
                   <Box color="green" as="span">
                     Connection Secure
                   </Box>

--- a/tgui/packages/tgui/interfaces/AntagInfoChangeling.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoChangeling.tsx
@@ -170,16 +170,16 @@ const AbilitiesSection = () => {
           <Stack fill vertical>
             <Stack.Item textColor="label" grow>
               Your
-              <span style={absorbstyle}>&ensp;Absorb DNA</span> ability allows
+              <span style={absorbstyle}>{'\u2002'}Absorb DNA</span> ability allows
               you to steal the DNA and memories of a victim. The
-              <span style={absorbstyle}>&ensp;Extract DNA Sting</span> ability
+              <span style={absorbstyle}>{'\u2002'}Extract DNA Sting</span> ability
               also steals the DNA of a victim, and is undetectable, but does not
               grant you their memories or speech patterns.
             </Stack.Item>
             <Stack.Divider />
             <Stack.Item textColor="label" grow>
               Your
-              <span style={revivestyle}>&ensp;Reviving Stasis</span> ability
+              <span style={revivestyle}>{'\u2002'}Reviving Stasis</span> ability
               allows you to revive. It means nothing short of a complete body
               destruction can stop you! Obviously, this is loud and so should
               not be done in front of people you are not planning on silencing.
@@ -191,7 +191,7 @@ const AbilitiesSection = () => {
           <Stack fill vertical>
             <Stack.Item textColor="label" grow>
               Your
-              <span style={transformstyle}>&ensp;Transform</span> ability allows
+              <span style={transformstyle}>{'\u2002'}Transform</span> ability allows
               you to change into the form of those you have collected DNA from,
               lethally and nonlethally. It will also mimic (NOT REAL CLOTHING)
               the clothing they were wearing for every slot you have open.
@@ -199,7 +199,7 @@ const AbilitiesSection = () => {
             <Stack.Divider />
             <Stack.Item textColor="label" grow>
               The
-              <span style={storestyle}>&ensp;Cellular Emporium</span> is where
+              <span style={storestyle}>{'\u2002'}Cellular Emporium</span> is where
               you purchase more abilities beyond your starting kit. You have 10
               genetic points to spend on abilities and you are able to readapt
               after absorbing a body, refunding your points for different kits.

--- a/tgui/packages/tgui/interfaces/AntagInfoHeretic.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoHeretic.tsx
@@ -138,18 +138,18 @@ const FlavorSection = () => {
       <Stack vertical textAlign="center" fontSize="14px">
         <Stack.Item>
           <i>
-            Another day at a meaningless job. You feel a&nbsp;
+            Another day at a meaningless job. You feel a{'\u00A0'}
             <span style={hereticBlue}>shimmer</span>
-            &nbsp;around you, as a realization of something&nbsp;
+            {'\u00A0'}around you, as a realization of something{'\u00A0'}
             <span style={hereticRed}>strange</span>
-            &nbsp;in the air unfolds. You look inwards and discover something
+            {'\u00A0'}in the air unfolds. You look inwards and discover something
             that will change your life.
           </i>
         </Stack.Item>
         <Stack.Item>
           <b>
             The <span style={hereticPurple}>Gates of Mansus</span>
-            &nbsp;open up to your mind.
+            {'\u00A0'}open up to your mind.
           </b>
         </Stack.Item>
       </Stack>
@@ -162,39 +162,39 @@ const GuideSection = () => {
     <Stack.Item>
       <Stack vertical fontSize="12px">
         <Stack.Item>
-          - Find reality smashing&nbsp;
+          - Find reality smashing{'\u00A0'}
           <span style={hereticPurple}>influences</span>
-          &nbsp;around the station invisible to the normal eye and&nbsp;
-          <b>right click</b> on them to harvest them for&nbsp;
+          {'\u00A0'}around the station invisible to the normal eye and{'\u00A0'}
+          <b>right click</b> on them to harvest them for{'\u00A0'}
           <span style={hereticBlue}>knowledge points</span>. Tapping them makes
           them visible to all after a short time. Dreaming of Mansus may help to
           find them.
         </Stack.Item>
         <Stack.Item>
-          - Use your&nbsp;
+          - Use your{'\u00A0'}
           <span style={hereticRed}>Living Heart action</span>
-          &nbsp;to track down&nbsp;
+          {'\u00A0'}to track down{'\u00A0'}
           <span style={hereticRed}>sacrifice targets</span>, but be careful:
           Pulsing it will produce a heartbeat sound that nearby people may hear.
           This action is tied to your <b>heart</b> - if you lose it, you must
           complete a ritual to regain it.
         </Stack.Item>
         <Stack.Item>
-          - Draw a&nbsp;
+          - Draw a{'\u00A0'}
           <span style={hereticGreen}>transmutation rune</span> by using a
-          drawing tool (a pen or crayon) on the floor while having&nbsp;
+          drawing tool (a pen or crayon) on the floor while having{'\u00A0'}
           <span style={hereticGreen}>Mansus Grasp</span>
-          &nbsp;active in your other hand. This rune allows you to complete
+          {'\u00A0'}active in your other hand. This rune allows you to complete
           rituals and sacrifices.
         </Stack.Item>
         <Stack.Item>
           - Follow your <span style={hereticRed}>Living Heart</span> to find
-          your targets. Bring them back to a&nbsp;
+          your targets. Bring them back to a{'\u00A0'}
           <span style={hereticGreen}>transmutation rune</span> in critical or
-          worse condition to&nbsp;
-          <span style={hereticRed}>sacrifice</span> them for&nbsp;
+          worse condition to{'\u00A0'}
+          <span style={hereticRed}>sacrifice</span> them for{'\u00A0'}
           <span style={hereticBlue}>knowledge points</span>. The Mansus{' '}
-          <b>ONLY</b> accepts targets pointed to by the&nbsp;
+          <b>ONLY</b> accepts targets pointed to by the{'\u00A0'}
           <span style={hereticRed}>Living Heart</span>.
         </Stack.Item>
         <Stack.Item>
@@ -232,15 +232,15 @@ const InformationSection = (props) => {
           </Stack.Item>
         )}
         <Stack.Item>
-          You have <b>{charges || 0}</b>&nbsp;
+          You have <b>{charges || 0}</b>{'\u00A0'}
           <span style={hereticBlue}>
             knowledge point{charges !== 1 ? 's' : ''}
           </span>
           .
         </Stack.Item>
         <Stack.Item>
-          You have made a total of&nbsp;
-          <b>{total_sacrifices || 0}</b>&nbsp;
+          You have made a total of{'\u00A0'}
+          <b>{total_sacrifices || 0}</b>{'\u00A0'}
           <span style={hereticRed}>sacrifices</span>.
         </Stack.Item>
       </Stack>
@@ -348,7 +348,7 @@ const ResearchInfo = (props) => {
   return (
     <Stack vertical fill>
       <Stack.Item fontSize="20px" textAlign="center">
-        You have <b>{charges || 0}</b>&nbsp;
+        You have <b>{charges || 0}</b>{'\u00A0'}
         <span style={hereticBlue}>
           knowledge point{charges !== 1 ? 's' : ''}
         </span>{' '}

--- a/tgui/packages/tgui/interfaces/AntagInfoMalf.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoMalf.tsx
@@ -158,7 +158,7 @@ function CodewordsSection(props) {
                 as if you&apos;re one of their own. Proceed with caution,
                 however, as everyone is a potential foe.
                 <span style={badstyle}>
-                  &ensp;The speech recognition subsystem has been configured to
+                  {'\u2002'}The speech recognition subsystem has been configured to
                   flag these codewords.
                 </span>
               </BlockQuote>

--- a/tgui/packages/tgui/interfaces/AntagInfoMorph.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoMorph.tsx
@@ -30,17 +30,17 @@ export const AntagInfoMorph = (props) => {
                 the object in question will also work.
               </span>{' '}
               <span style={badstyle}>
-                &ensp;This process will alert any nearby observers.
+                {'\u2002'}This process will alert any nearby observers.
               </span>{' '}
               While morphed, you move faster, but are unable to attack creatures
               or eat anything. In addition,
               <span style={badstyle}>
-                &ensp;anyone within three tiles will note an uncanny wrongness
+                {'\u2002'}anyone within three tiles will note an uncanny wrongness
                 if examining you.
               </span>{' '}
               You can attack any item or dead creature to consume it -
               <span style={goodstyle}>
-                &ensp;corpses will restore your health.
+                {'\u2002'}corpses will restore your health.
               </span>{' '}
               Finally, you can restore yourself to your original form while
               morphed by{' '}

--- a/tgui/packages/tgui/interfaces/AntagInfoNightmare.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoNightmare.tsx
@@ -26,22 +26,22 @@ export const AntagInfoNightmare = (props) => {
                     strong powers in the darkness, becoming nigh unbeatable.
                     Unfortunately, you wither and burn away in the light. You
                     must use your
-                    <span style={noticestyle}>&ensp;light eater</span> to dim
+                    <span style={noticestyle}>{'\u2002'}light eater</span> to dim
                     the station, making hunting easier.
                   </BlockQuote>
                 </Stack.Item>
                 <Stack.Divider />
                 <Stack.Item textColor="label">
-                  <span style={tipstyle}>Tip #1:&ensp;</span>
+                  <span style={tipstyle}>Tip #1:{'\u2002'}</span>
                   Move often. The station will be hunting you after you are
                   discovered, so don&apos;t stay in one area for long.
                   <br />
-                  <span style={tipstyle}>Tip #2:&ensp;</span>
+                  <span style={tipstyle}>Tip #2:{'\u2002'}</span>
                   Pick unfair fights. You are incredibly strong in one versus
                   one situations, use it. The more you fight, the harder it will
                   be to keep it dark.
                   <br />
-                  <span style={tipstyle}>Tip #3:&ensp;</span>
+                  <span style={tipstyle}>Tip #3:{'\u2002'}</span>
                   Fully destroy APCs when possible. Instead of hunting lights
                   that can be fixed, hunt the APCs which are harder to repair.
                 </Stack.Item>

--- a/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
@@ -164,7 +164,7 @@ const CodewordsSection = (props) => {
                 conversation to identify other agents. Proceed with caution,
                 however, as everyone is a potential foe.
                 <span style={badstyle}>
-                  &ensp;You have memorized the codewords, allowing you to
+                  {'\u2002'}You have memorized the codewords, allowing you to
                   recognise them when heard.
                 </span>
               </BlockQuote>

--- a/tgui/packages/tgui/interfaces/AntagInfoVoidwalker.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoVoidwalker.tsx
@@ -28,16 +28,16 @@ export const AntagInfoVoidwalker = (props) => {
                 </Stack.Item>
                 <Stack.Divider />
                 <Stack.Item textColor="label">
-                  <span style={tipstyle}>Survive:&ensp;</span>
+                  <span style={tipstyle}>Survive:{'\u2002'}</span>
                   You have unrivaled freedom. Remain in space and no one can
                   stop you. You can move through windows, so stay near them to
                   always have a way out.
                   <br />
-                  <span style={tipstyle}>Hunt:&ensp;</span>
+                  <span style={tipstyle}>Hunt:{'\u2002'}</span>
                   Pick unfair fights. Look for inattentive targets and strike at
                   them when they don&apos;t expect you.
                   <br />
-                  <span style={tipstyle}>Abduct:&ensp;</span>
+                  <span style={tipstyle}>Abduct:{'\u2002'}</span>
                   Your Unsettle ability stuns and drains your targets. Finish
                   them with your void window and use it to pop a window, drag
                   them into space and use an empty hand to kidnap them.

--- a/tgui/packages/tgui/interfaces/ArmamentStation.jsx
+++ b/tgui/packages/tgui/interfaces/ArmamentStation.jsx
@@ -99,7 +99,7 @@ export const ArmamentStation = (props) => {
                                     verticalAlign: 'middle',
                                   }}
                                 />
-                                &nbsp;{item.name}
+                                {'\u00A0'}{item.name}
                               </Button>
                             </Stack.Item>
                           ))}

--- a/tgui/packages/tgui/interfaces/BorerEvolution.tsx
+++ b/tgui/packages/tgui/interfaces/BorerEvolution.tsx
@@ -123,7 +123,7 @@ const EvoInfo = (props) => {
       <Stack.Item grow>
         <Stack vertical height="100%">
           <Stack.Item fontSize="20px" textAlign="center">
-            You have <b>{evolution_points || 0}</b>&nbsp;
+            You have <b>{evolution_points || 0}</b>{'\u00A0'}
             <span style={borerColor}>
               evolution point{evolution_points !== 1 ? 's' : ''}
             </span>{' '}

--- a/tgui/packages/tgui/interfaces/CargoImportConsole.jsx
+++ b/tgui/packages/tgui/interfaces/CargoImportConsole.jsx
@@ -95,7 +95,7 @@ export const CargoImportConsole = (props) => {
                                     'horizontal-align': 'middle',
                                   }}
                                 />
-                                &nbsp;{item.name}
+                                {'\u00A0'}{item.name}
                               </Button>
                             </Stack.Item>
                           ))}

--- a/tgui/packages/tgui/interfaces/ClockworkSlab.jsx
+++ b/tgui/packages/tgui/interfaces/ClockworkSlab.jsx
@@ -89,8 +89,8 @@ const ClockworkHelp = (props) => {
           unable to function.
           <br />
           <b>
-            Install&nbsp;
-            <font color={brassColor}>Integration Cogs&nbsp;</font>
+            Install{'\u00A0'}
+            <font color={brassColor}>Integration Cogs{'\u00A0'}</font>
             to unlock more scriptures and siphon power!
           </b>
           <br />
@@ -100,18 +100,18 @@ const ClockworkHelp = (props) => {
         <Section>
           Most scriptures require <b>cogs</b> to unlock.
           <br />
-          Invoke&nbsp;
+          Invoke{'\u00A0'}
           <font color={brassColor}>
-            <b>Integration Cog&nbsp;</b>
+            <b>Integration Cog{'\u00A0'}</b>
           </font>
-          to summon an Integration Cog, which can be placed into any&nbsp;
-          <b>APC&nbsp;</b>
+          to summon an Integration Cog, which can be placed into any{'\u00A0'}
+          <b>APC{'\u00A0'}</b>
           on the station.
           <br />
-          Slice open the&nbsp;
-          <b>APC&nbsp;</b>
-          with the&nbsp;
-          <b>Integration Cog&nbsp;</b>
+          Slice open the{'\u00A0'}
+          <b>APC{'\u00A0'}</b>
+          with the{'\u00A0'}
+          <b>Integration Cog{'\u00A0'}</b>
           and then insert it in to begin siphoning power. However, you will only
           gain a cog after the Integration Cog has been inside the APC for 5
           minutes.
@@ -122,9 +122,9 @@ const ClockworkHelp = (props) => {
         <Section>
           Some scriptures and equipment take more than simply cogs to unlock.
           <br />
-          The&nbsp;
+          The{'\u00A0'}
           <font color={brassColor}>
-            <b>Technologist&apos;s Lectern&nbsp;</b>
+            <b>Technologist&apos;s Lectern{'\u00A0'}</b>
           </font>
           can be used to research normally-locked equipment and abilities, but
           not easily.
@@ -143,21 +143,21 @@ const ClockworkHelp = (props) => {
           </b>
           <br />
           <b>
-            <font color={brassColor}>Structures:&nbsp;</font>
+            <font color={brassColor}>Structures:{'\u00A0'}</font>
           </b>
           A variety of invaluable structures are available to you, allowing
           effective defense of your sanctum. Use your Slab on a structure to
           gain extra information.
           <br />
           <b>
-            <font color={brassColor}>Traps:&nbsp;</font>
+            <font color={brassColor}>Traps:{'\u00A0'}</font>
           </b>
           Traps are useful contraptions, able to be created at a{' '}
           <font color={tinkerCache}>Tinkerer&apos;s Cache</font>. Use your Slab
           to link traps and triggers together.
           <br />
           <b>
-            <font color={clockMarauder}>Clockwork Marauder:&nbsp;</font>
+            <font color={clockMarauder}>Clockwork Marauder:{'\u00A0'}</font>
           </b>
           A powerful shell that can deflect attacks and delivers a strong blow
           in close quarter combat.
@@ -168,7 +168,7 @@ const ClockworkHelp = (props) => {
       <Collapsible title="Tips" color="average">
         <Section>
           <b>
-            <font color={brassColor}>Vitality:&nbsp;</font>
+            <font color={brassColor}>Vitality:{'\u00A0'}</font>
           </b>
           You need vitality to create{' '}
           <font color={clockMarauder}>Clockwork Marauders</font>, which is
@@ -176,20 +176,20 @@ const ClockworkHelp = (props) => {
           <font color={brassColor}>Vitality Sigil</font>.
           <br />
           <b>
-            <font color={brassColor}>Power:&nbsp;</font>
+            <font color={brassColor}>Power:{'\u00A0'}</font>
           </b>
           Watch your power upkeep! You&apos;re dependent on your cogged APCs to
           stay powered, and a lot of structures can drain it quickly.
           <br />
           <b>
-            <font color={brassColor}>Your Base:&nbsp;</font>
+            <font color={brassColor}>Your Base:{'\u00A0'}</font>
           </b>
           Make sure to have a defensible base of operations! You&apos;re
           significantly stronger while on brass tiles, so make your home
           indefensible.
           <br />
           <b>
-            <font color={replicaFab}>Replica Fabricator:&nbsp;</font>
+            <font color={replicaFab}>Replica Fabricator:{'\u00A0'}</font>
           </b>
           The Replica Fabricator is one of the strongest tools available to you,
           via the <font color={tinkerCache}>Tinkerer&apos;s Cache</font>. It
@@ -198,7 +198,7 @@ const ClockworkHelp = (props) => {
           non-cultists.
           <br />
           <b>
-            <font color={brassColor}>Nar&apos;sie:&nbsp;</font>
+            <font color={brassColor}>Nar&apos;sie:{'\u00A0'}</font>
           </b>
           Nar&apos;sian cultists are your greatest foe! Some of your spells are
           less effective on them, and vice-versa. What remains of Ratvar may

--- a/tgui/packages/tgui/interfaces/FoodPreferences.tsx
+++ b/tgui/packages/tgui/interfaces/FoodPreferences.tsx
@@ -138,7 +138,7 @@ export const FoodPreferences = (props) => {
                                 fontSize={0.75}
                                 verticalAlign={'top'}
                               >
-                                &nbsp;
+                                {'\u00A0'}
                                 <Icon name="star" style={{ color: 'orange' }} />
                               </Box>
                             </Tooltip>

--- a/tgui/packages/tgui/interfaces/GlassBlowing.tsx
+++ b/tgui/packages/tgui/interfaces/GlassBlowing.tsx
@@ -151,7 +151,7 @@ export const GlassBlowing = (props) => {
                           }
                           onClick={() => act('Blow')}
                         />
-                        &nbsp;x{glass.stepsRemaining.blow}
+                        {'\u00A0'}x{glass.stepsRemaining.blow}
                       </Table.Cell>
                     )}
                     {glass.stepsRemaining.spin !== 0 && (
@@ -169,7 +169,7 @@ export const GlassBlowing = (props) => {
                           }
                           onClick={() => act('Spin')}
                         />
-                        &nbsp;x{glass.stepsRemaining.spin}
+                        {'\u00A0'}x{glass.stepsRemaining.spin}
                       </Table.Cell>
                     )}
                     {glass.stepsRemaining.paddle !== 0 && (
@@ -181,7 +181,7 @@ export const GlassBlowing = (props) => {
                           tooltip={'You need to use a paddle.'}
                           onClick={() => act('Paddle')}
                         />
-                        &nbsp;x{glass.stepsRemaining.paddle}
+                        {'\u00A0'}x{glass.stepsRemaining.paddle}
                       </Table.Cell>
                     )}
                     {glass.stepsRemaining.shear !== 0 && (
@@ -193,7 +193,7 @@ export const GlassBlowing = (props) => {
                           tooltip={'You need to use shears.'}
                           onClick={() => act('Shear')}
                         />
-                        &nbsp;x{glass.stepsRemaining.shear}
+                        {'\u00A0'}x{glass.stepsRemaining.shear}
                       </Table.Cell>
                     )}
                     {glass.stepsRemaining.jacks !== 0 && (
@@ -205,7 +205,7 @@ export const GlassBlowing = (props) => {
                           tooltip={'You need to use jacks.'}
                           onClick={() => act('Jacks')}
                         />
-                        &nbsp;x{glass.stepsRemaining.jacks}
+                        {'\u00A0'}x{glass.stepsRemaining.jacks}
                       </Table.Cell>
                     )}
                   </Stack.Item>

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.tsx
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.tsx
@@ -65,7 +65,7 @@ const BarLabel = (props) => {
           <Box align="center" color="red">
             Empty
           </Box>
-          <Box className="hypertorus__unselectable">&nbsp;</Box>
+          <Box className="hypertorus__unselectable">{'\u00A0'}</Box>
         </>
       )}
     </>

--- a/tgui/packages/tgui/interfaces/NtosDeptOrder.tsx
+++ b/tgui/packages/tgui/interfaces/NtosDeptOrder.tsx
@@ -208,7 +208,7 @@ const DepartmentCatalog = () => {
                   </Stack.Item>
                   <Stack.Item>
                     <CooldownEstimate cost={pack.cost} />
-                    &ensp;
+                    {'\u2002'}
                     <Button
                       onClick={() =>
                         act('order', {

--- a/tgui/packages/tgui/interfaces/PlayerTicketHistory.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerTicketHistory.tsx
@@ -167,7 +167,7 @@ const Cache = (props: CacheProps) => {
   return (
     <Section>
       <div>
-        Query and cache:&nbsp;
+        Query and cache:{'\u00A0'}
         <Input
           value={props.cacheInput}
           onBlur={(value) => props.setCacheInput(value.toLowerCase())}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/index.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/index.tsx
@@ -146,7 +146,7 @@ export function LoadoutPage(props) {
         )}
         <Section
           fitted
-          title="&nbsp;"
+          title="{'\u00A0'}"
           buttons={
             <Input
               width="200px"

--- a/tgui/packages/tgui/interfaces/RapidConstructionDevice.tsx
+++ b/tgui/packages/tgui/interfaces/RapidConstructionDevice.tsx
@@ -41,7 +41,7 @@ export const MatterItem = (props) => {
   const { matterLeft } = data;
   return (
     <LabeledList.Item label="Units Left">
-      &nbsp;{matterLeft} Units
+      {'\u00A0'}{matterLeft} Units
     </LabeledList.Item>
   );
 };

--- a/tgui/packages/tgui/interfaces/Uplink/index.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/index.tsx
@@ -236,7 +236,7 @@ export class Uplink extends Component<{}, UplinkState> {
             {item.cost_override_string || `${item.cost} TC`}
             {has_progression ? (
               <>
-                ,&nbsp;
+                ,{'\u00A0'}
                 <Box as="span">
                   {calculateDangerLevel(item.progression_minimum, true)}
                 </Box>
@@ -278,7 +278,7 @@ export class Uplink extends Component<{}, UplinkState> {
                           <Box>
                             <Box>
                               <Box>Your current level of threat.</Box> Threat
-                              determines what items you can purchase.&nbsp;
+                              determines what items you can purchase.{'\u00A0'}
                               <Box mt={0.5}>
                                 {/* A minute in deciseconds */}
                                 Threat passively increases by{' '}
@@ -287,7 +287,7 @@ export class Uplink extends Component<{}, UplinkState> {
                                     current_progression_scaling,
                                   )}
                                 </Box>
-                                &nbsp;every minute
+                                {'\u00A0'}every minute
                               </Box>
                               {dangerLevelsTooltip}
                             </Box>

--- a/tgui/packages/tgui/interfaces/VotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/VotePanel.tsx
@@ -348,7 +348,7 @@ const TimePanel = (props) => {
       <Section>
         <Stack justify="space-between">
           <Box fontSize={1.5}>
-            Time Remaining:&nbsp;
+            Time Remaining:{'\u00A0'}
             {currentVote?.timeRemaining || 0}s
           </Box>
           {!!user.isLowerAdmin && (


### PR DESCRIPTION
## Changelog

:cl:
fix: Replaced &nbsp; and &ensp; in UI and text. If there's anywhere displays {''} please report to coder
/:cl:
