### PR TITLE
fix: quantum console sprite with keyboard

### DIFF
--- a/code/modules/bitrunning/objects/quantum_console.dm
+++ b/code/modules/bitrunning/objects/quantum_console.dm
@@ -2,7 +2,7 @@
 	name = "quantum console"
 
 	circuit = /obj/item/circuitboard/computer/quantum_console
-	icon_keyboard = "mining"
+	icon_keyboard = "mining_key"
 	icon_screen = "bitrunning"
 	req_access = list(ACCESS_MINING)
 	/// The server this console is connected to.


### PR DESCRIPTION
## Changelog

:cl:
image: quantum console sprite now shows with keyboard
/:cl: