### PR TITLE
balance: no flashbang stun/knockdown in 1 tile

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -46,9 +46,11 @@
 		living_mob.Knockdown(200)
 		living_mob.soundbang_act(1, 200, 10, 15)
 	else
-		if(distance <= 1) // Adds more stun as to not prime n' pull (#45381)
-			living_mob.Paralyze(5)
-			living_mob.Knockdown(30)
+		// SS1984 REMOVAL START
+		// if(distance <= 1) // Adds more stun as to not prime n' pull (#45381)
+		// 	living_mob.Paralyze(5)
+		// 	living_mob.Knockdown(30)
+		// SS1984 REMOVAL END
 		living_mob.soundbang_act(1, max(200 / max(1, distance), 60), rand(0, 5))
 
 


### PR DESCRIPTION
## Changelog

:cl:
balance: Flashbangs no longer stun/knockdown in 1 tile ignoring protection (still works if detonated in backpack/at same tile)
/:cl: