### PR TITLE
add: gulag auto links to station silo, silos can link from mining to station

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -76207,7 +76207,7 @@
 /area/station/maintenance/department/medical/central)
 "vER" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/ore_redemption,
+/obj/machinery/mineral/ore_redemption/gulag_autolink,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "vEU" = (

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -3866,7 +3866,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 9
 	},
-/obj/machinery/mineral/ore_redemption,
+/obj/machinery/mineral/ore_redemption/gulag_autolink,
 /turf/open/floor/iron/checker,
 /area/mine/laborcamp)
 "uD" = (

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -51322,7 +51322,7 @@
 /area/station/service/bar)
 "nJm" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/mineral/ore_redemption,
+/obj/machinery/mineral/ore_redemption/gulag_autolink,
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -42,6 +42,7 @@
 	var/datum/techweb/stored_research
 	/// Linkage to the ORM silo
 	var/datum/component/remote_materials/materials
+	var/force_connect_to_silo = FALSE // SS1984 ADDITION
 
 /obj/machinery/mineral/ore_redemption/offstation
 	circuit = /obj/item/circuitboard/machine/ore_redemption/offstation
@@ -62,6 +63,7 @@
 	materials = AddComponent( \
 		/datum/component/remote_materials, \
 		mapload, \
+		force_connect = force_connect_to_silo, \
 		mat_container_signals = local_signals \
 	)
 

--- a/modular_ss220/modules/gulag_tweaks/machine_redemption.dm
+++ b/modular_ss220/modules/gulag_tweaks/machine_redemption.dm
@@ -1,0 +1,2 @@
+/obj/machinery/mineral/ore_redemption/gulag_autolink
+	force_connect_to_silo = TRUE

--- a/modular_ss220/modules/gulag_tweaks/remote_materials.dm
+++ b/modular_ss220/modules/gulag_tweaks/remote_materials.dm
@@ -1,0 +1,19 @@
+/datum/component/remote_materials
+	var/allow_link_from_mining = TRUE
+
+/datum/component/remote_materials/check_z_level(obj/silo_to_check = silo)
+	. = ..()
+	if (!.)
+		if (!allow_link_from_mining) // vanila way
+			return FALSE
+
+		var/turf/source_loc = get_turf(silo_to_check)
+		var/turf/checking_loc = get_turf(parent)
+		if (!source_loc || !checking_loc)
+			return FALSE
+
+		if (is_station_level(source_loc.z) && is_mining_level(checking_loc.z))
+			return TRUE
+
+		return source_loc.z == checking_loc.z
+	return .

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9306,4 +9306,6 @@
 #include "modular_ss220\modules\liquid_controller_lagwatcher\liquid_controller.dm"
 #include "modular_ss220\modules\security_minor_1984\security.dm"
 #include "modular_ss220\modules\gulag_tweaks\minerals.dm"
+#include "modular_ss220\modules\gulag_tweaks\machine_redemption.dm"
+#include "modular_ss220\modules\gulag_tweaks\remote_materials.dm"
 // END_INCLUDE


### PR DESCRIPTION
## Changelog

:cl:
add: Ore Redemption at labor camp automatically link to station silo
add: Mining ore-redemptions can link to station ore silo (away levels still can't)
/:cl: