### PR TITLE
fix: job estimation

### DIFF
--- a/modular_nova/master_files/code/modules/mob/dead/dead.dm
+++ b/modular_nova/master_files/code/modules/mob/dead/dead.dm
@@ -15,5 +15,15 @@
 		. += "Players Ready: [SSticker.totalPlayersReady]"
 		. += "Admins Ready: [SSticker.total_admins_ready] / [length(GLOB.admins)]"
 	if(length(SSstatpanels.player_ready_data) || length(SSstatpanels.command_player_ready_data))
+		// SS1984 ADDITION START
+		// In case it was disabled in config: show only to non-deadminned admins
+		var/show_stat = CONFIG_GET(flag/show_job_estimation)
+		if (!show_stat)
+			show_stat = (client in GLOB.admins)
+			if (show_stat)
+				show_stat = !(client in GLOB.deadmins)
+		if (!show_stat)
+			return .
+		// SS1984 ADDITION END
 		. += SSstatpanels.get_job_estimation()
 

--- a/modular_nova/modules/job_estimation/job_estimation.dm
+++ b/modular_nova/modules/job_estimation/job_estimation.dm
@@ -1,6 +1,6 @@
 
 /datum/config_entry/flag/show_job_estimation
-	default = TRUE
+	//default = TRUE // SS1984 REMOVAL
 
 /datum/preference/toggle/ready_job
 	savefile_key = "ready_job"
@@ -42,8 +42,8 @@
 /datum/controller/subsystem/statpanels/proc/add_job_estimation(mob/dead/new_player/player)
 	if(isnull(player.client))
 		return
-	if(!CONFIG_GET(flag/show_job_estimation))
-		return
+	// if(!CONFIG_GET(flag/show_job_estimation)) // SS1984 REMOVAL
+	// 	return  // SS1984 REMOVAL
 
 	var/datum/preferences/prefs = player.client?.prefs
 	var/datum/job/player_job = prefs?.get_highest_priority_job()


### PR DESCRIPTION
## Changelog

:cl:
fix: Job estimation now doesn't show when disabled in config
qol: Admins (non-deadminned) still can see job estimations
/:cl: