### PR TITLE
fix: total admins ready for mentors

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -187,7 +187,7 @@ SUBSYSTEM_DEF(ticker)
 			for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
 				if(player.ready == PLAYER_READY_TO_PLAY)
 					++totalPlayersReady
-					if(player.client?.holder)
+					if(player.client?.holder && (player.client in GLOB.admins)) // SS1984 EDIT, original: if(player.client?.holder)
 						++total_admins_ready
 
 			if(start_immediately)


### PR DESCRIPTION
## Changelog

:cl:
fix: Total Admins Ready is no longer shows mentors, no longer 3/2 admins ready
/:cl: