### PR TITLE
config: midround antags rulesets for lowpop

### DIFF
--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -550,7 +550,7 @@
 			]
 		},
 		"Quiet": {
-			"cost": 0.000001
+			"cost": 0.1
 		}
 	},
 
@@ -562,6 +562,7 @@
 			"required_candidates": 1,
 			"minimum_required_age": 0,
 			"requirements": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
+			"required_enemies": [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 24
 			},
@@ -600,6 +601,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 50
 			},
@@ -672,6 +674,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 2, 2, 1, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 24
 			},
@@ -701,6 +704,7 @@
 				20,
 				10
 			],
+			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 15,
 				"offset": 1
@@ -731,6 +735,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 15,
 				"offset": 1
@@ -761,6 +766,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 25
 			},
@@ -790,6 +796,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 25
 			},
@@ -821,6 +828,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 12,
 				"offset": 1
@@ -852,6 +860,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 24
 			},
@@ -882,6 +891,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 99
 			},
@@ -912,6 +922,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 2, 1, 1, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 20,
 				"offset": 1
@@ -943,6 +954,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 3, 3, 2, 1, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 25
 			},
@@ -973,6 +985,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 12
 			},
@@ -1003,6 +1016,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 24
 			},
@@ -1062,6 +1076,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 2, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 15,
 				"offset": 2
@@ -1093,6 +1108,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 2, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 15,
 				"offset": 3
@@ -1123,6 +1139,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 10
 			},
@@ -1153,6 +1170,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 2, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 20
 			},
@@ -1183,6 +1201,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 10
 			},
@@ -1213,6 +1232,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 24
 			},
@@ -1242,6 +1262,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 99
 			},
@@ -1271,6 +1292,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 99
 			},
@@ -1301,6 +1323,7 @@
 				10,
 				10
 			],
+			"required_enemies": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0 ],
 			"antag_cap": {
 				"denominator": 18
 			},

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -560,6 +560,7 @@
 			"scaling_cost": 10,
 			"weight": 5,
 			"required_candidates": 1,
+			"minimum_players": 5,
 			"minimum_required_age": 0,
 			"requirements": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
 			"required_enemies": [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
@@ -661,6 +662,7 @@
 			"scaling_cost": 15,
 			"weight": 2,
 			"required_candidates": 1,
+			"minimum_players": 20,
 			"minimum_required_age": 0,
 			"requirements": [
 				100,
@@ -691,6 +693,7 @@
 			"scaling_cost": 10,
 			"weight": 2,
 			"required_candidates": 3,
+			"minimum_players": 30,
 			"minimum_required_age": 0,
 			"requirements": [
 				100,
@@ -722,6 +725,7 @@
 			"scaling_cost": 101,
 			"weight": 2,
 			"required_candidates": 3,
+			"minimum_players": 30,
 			"minimum_required_age": 0,
 			"requirements": [
 				100,
@@ -1126,6 +1130,7 @@
 			"scaling_cost": 10,
 			"weight": 2,
 			"required_candidates": 1,
+			"minimum_players": 5,
 			"minimum_required_age": 0,
 			"requirements": [
 				10,
@@ -1157,6 +1162,7 @@
 			"scaling_cost": 16,
 			"weight": 2,
 			"required_candidates": 1,
+			"minimum_players": 5,
 			"minimum_required_age": 0,
 			"requirements": [
 				100,
@@ -1342,6 +1348,7 @@
 			"scaling_cost": 10,
 			"weight": 4,
 			"required_candidates": 1,
+			"minimum_players": 5,
 			"minimum_required_age": 0,
 			"requirements": [
 				10,
@@ -1447,6 +1454,7 @@
 			"scaling_cost": 12,
 			"weight": 3,
 			"required_candidates": 1,
+			"minimum_players": 10,
 			"minimum_required_age": 0,
 			"requirements": [
 				100,
@@ -1497,6 +1505,7 @@
 			"scaling_cost": 12,
 			"weight": 2,
 			"required_candidates": 1,
+			"minimum_players": 10,
 			"minimum_required_age": 0,
 			"requirements": [
 				100,


### PR DESCRIPTION
## Changelog

:cl:
config: All midround antag rulesets except sentient disease and borers now require at least 1 enemy (security/heads) for lowpop. Some rulesets require more than 1.
config: Midround antags rulesets now require at least 5 players, for which they didn't required already. This includes: Syndicate Sleeper, Obsessed. And relevant latejoins. If you want such antagonists at all - you need at least 1 security (captain would fit as well)
config: Changes for minimum players for other rulesets, such as nuclear assault, wizard, etc...
config: Quiet ruleset now cost 0.1 threat instead of 0.00001...
/:cl:
