### PR TITLE
del: revert nova max length message 2048 -> 1024

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -110,7 +110,7 @@
 #define FOLLOW_OR_TURF_LINK(alice, bob, turfy) "<a href=byond://?src=[REF(alice)];follow=[REF(bob)];x=[turfy.x];y=[turfy.y];z=[turfy.z]>(F)</a>"
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
-#define MAX_MESSAGE_LEN 2048 //NOVA EDIT CHANGE - ORIGINAL 1024 - I SAID DOUBLE IT!! FUCK THE WARNING!
+#define MAX_MESSAGE_LEN 1024 // SS1984 REVERT BACK TO TG 1024 instead of 2048 nova's
 #define MAX_NAME_LEN 42
 #define MAX_BROADCAST_LEN 512
 #define MAX_CHARTER_LEN 80


### PR DESCRIPTION
## Changelog

:cl:
del: revert Nova's Max message length 2048 -> 1024 (as it is in TG)
/:cl:
