### PR TITLE
add: handgun shoulder holster

### DIFF
--- a/modular_ss220/modules/security_minor_1984/shoulder_holsters/accessory_actions.dm
+++ b/modular_ss220/modules/security_minor_1984/shoulder_holsters/accessory_actions.dm
@@ -1,0 +1,19 @@
+// for clothing accessories like holsters
+/datum/action/item_action/accessory
+	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
+
+/datum/action/item_action/accessory/IsAvailable(feedback = FALSE)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/obj/item/item_target = target
+	if (!item_target)
+		return FALSE
+	if(item_target.loc == owner)
+		return TRUE
+	if(istype(item_target.loc, /obj/item/clothing/under) && item_target.loc.loc == owner)
+		return TRUE
+	return FALSE
+
+/datum/action/item_action/accessory/holster
+	name = "Holster"

--- a/modular_ss220/modules/security_minor_1984/shoulder_holsters/biogenerator_designs.dm
+++ b/modular_ss220/modules/security_minor_1984/shoulder_holsters/biogenerator_designs.dm
@@ -1,0 +1,7 @@
+/datum/design/shoulder_holster
+	name = "Shoulder holster (handgun)"
+	id = "holster"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 200)
+	build_path = /obj/item/clothing/accessory/holster
+	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_BIO_MATERIALS)

--- a/modular_ss220/modules/security_minor_1984/shoulder_holsters/human_keybindings.dm
+++ b/modular_ss220/modules/security_minor_1984/shoulder_holsters/human_keybindings.dm
@@ -1,0 +1,17 @@
+#define COMSIG_KB_HUMAN_HOLSTER_DOWN "keybinding_human_holster_down"
+
+/datum/keybinding/human/holster
+	hotkey_keys = list("H")
+	name = "holster"
+	full_name = "Holster"
+	description = "Quickly draws an holstered gun in suit's shoulder holster. Doesn't work for belt holsters"
+	keybind_signal = COMSIG_KB_HUMAN_HOLSTER_DOWN
+
+/datum/keybinding/human/holster/down(client/user, turf/target)
+	. = ..()
+	var/mob/living/carbon/human/M = user.mob
+	if(!M.w_uniform)
+		return
+	var/obj/item/clothing/accessory/holster/H = locate() in M.w_uniform
+	H?.handle_holster_usage(M)
+	return TRUE

--- a/modular_ss220/modules/security_minor_1984/shoulder_holsters/shoulder_holster.dm
+++ b/modular_ss220/modules/security_minor_1984/shoulder_holsters/shoulder_holster.dm
@@ -1,0 +1,99 @@
+/obj/item/clothing/accessory/holster
+	name = "shoulder holster (handgun)"
+	desc = "A handgun holster."
+	icon_state = "holster"
+	inhand_icon_state = "holster"
+	worn_icon_state = "holster"
+	attachment_slot = CHEST
+	var/list/holster_allow = list(/obj/item/gun)
+	var/holster_allow_size = WEIGHT_CLASS_NORMAL
+	var/obj/item/gun/holstered = null
+	actions_types = list(/datum/action/item_action/accessory/holster)
+	w_class = WEIGHT_CLASS_NORMAL // so it doesn't fit in pockets
+
+/obj/item/clothing/accessory/holster/Destroy()
+	if(holstered?.loc == src) // Gun still in the holster
+		holstered.forceMove(loc)
+	holstered = null
+	return ..()
+
+//subtypes can override this to specify what can be holstered
+/obj/item/clothing/accessory/holster/proc/can_holster(obj/item/gun/W)
+	if(W.w_class > holster_allow_size)
+		return FALSE
+	if(!is_type_in_list(W, holster_allow))
+		return FALSE
+	return TRUE
+
+/obj/item/clothing/accessory/holster/proc/holster(obj/item/I, mob/living/carbon/human/user)
+	if(holstered)
+		to_chat(user, "<span class='warning'>There is already a [holstered] holstered here!</span>")
+		return
+
+	var/obj/item/gun/W = I
+	if(!W)
+		to_chat(user, "<span class='warning'>Only guns can be holstered!</span>")
+		return
+
+	if(!can_holster(W))
+		to_chat(user, "<span class='warning'>This [W.name] won't fit in [src]!</span>")
+		return
+
+	if(!user.canUnEquip(W, 0))
+		to_chat(user, "<span class='warning'>You can't let go of [W]!</span>")
+		return
+
+	holstered = W
+	user.temporarilyRemoveItemFromInventory(holstered)
+	holstered.forceMove(src)
+	holstered.add_fingerprint(user)
+	user.visible_message("<span class='notice'>[user] holsters [holstered].</span>", "<span class='notice'>You holster [holstered].</span>")
+
+/obj/item/clothing/accessory/holster/proc/unholster(mob/living/carbon/human/user)
+	if(!holstered)
+		return
+
+	if(isobj(user.get_active_held_item()) && isobj(user.get_inactive_held_item()))
+		to_chat(user, "<span class='warning'>You need an empty hand to draw [holstered]!</span>")
+	else
+		if(user.combat_mode)
+			usr.visible_message("<span class='warning'>[user] draws [holstered], ready to shoot!</span>", \
+			"<span class='warning'>You draw [holstered], ready to shoot!</span>")
+		else
+			user.visible_message("<span class='notice'>[user] draws [holstered], pointing it at the ground.</span>", \
+			"<span class='notice'>You draw [holstered], pointing it at the ground.</span>")
+		user.put_in_hands(holstered)
+		holstered.add_fingerprint(user)
+		holstered = null
+
+/obj/item/clothing/accessory/holster/emp_act(severity)
+	if(holstered)
+		holstered.emp_act(severity)
+	..()
+
+/obj/item/clothing/accessory/holster/examine(mob/user)
+	. = ..()
+	if(holstered)
+		. += "A [holstered] is holstered here."
+	else
+		. += "It is empty."
+
+/obj/item/clothing/accessory/holster/attack_self(mob/user, modifiers)
+	var/mob/living/carbon/human/carbon_user = user
+	if (carbon_user)
+		handle_holster_usage(carbon_user)
+
+/obj/item/clothing/accessory/holster/proc/handle_holster_usage(mob/living/carbon/human/user)
+	if(user.stat > SOFT_CRIT || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
+		return
+	if (user.IsParalyzed())
+		return
+
+	if(!holstered)
+		var/obj/item/gun/gun_in_hand = user.get_active_held_item()
+		if(!gun_in_hand)
+			to_chat(user, "<span class='warning'>You need your gun equipped to holster it.</span>")
+			return
+		holster(gun_in_hand, user)
+	else
+		unholster(user)

--- a/modular_ss220/modules/security_vouchers/machinery/vending/vending.dm
+++ b/modular_ss220/modules/security_vouchers/machinery/vending/vending.dm
@@ -8,10 +8,14 @@
 			return
 
 		var/list/available_kits = list(
-			"Hybrid Taser Kit" = list(/obj/item/gun/energy/e_gun/advtaser),
+			"Hybrid Taser Kit" = list(
+				/obj/item/gun/energy/e_gun/advtaser = 1,
+				/obj/item/clothing/accessory/holster = 1,
+				),
 			"Sol Pistol with incapacitator ammo Kit" = list(
 				/obj/item/gun/ballistic/automatic/pistol/sol/incapacitator_prefilled = 1,
-				/obj/item/ammo_box/magazine/c35sol_pistol/incapacitator = 2
+				/obj/item/ammo_box/magazine/c35sol_pistol/incapacitator = 2,
+				/obj/item/clothing/accessory/holster = 1,
 				),
 		)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9317,4 +9317,8 @@
 #include "modular_ss220\modules\gulag_tweaks\remote_materials.dm"
 #include "modular_ss220\modules\security_minor_1984\brigdoors.dm"
 #include "modular_ss220\modules\security_minor_1984\brid_cell_aas_config_entries.dm"
+#include "modular_ss220\modules\security_minor_1984\shoulder_holsters\shoulder_holster.dm"
+#include "modular_ss220\modules\security_minor_1984\shoulder_holsters\accessory_actions.dm"
+#include "modular_ss220\modules\security_minor_1984\shoulder_holsters\human_keybindings.dm"
+#include "modular_ss220\modules\security_minor_1984\shoulder_holsters\biogenerator_designs.dm"
 // END_INCLUDE


### PR DESCRIPTION
## Changelog

:cl:
add: Added handgun shoulder holster, works similar as MOD Shoulder Holster, but attaches to suit
add: Added hotkey for attachable shoulder holster (H by default)
add: Shoulder holster is added to all security weapon kits (hybrid taser kit, sol pistol...)
add: Shoulder holster added to biogenerator craft for 200 biomaterial
/:cl:

****
- [x] Проверено на локалке
