### PR TITLE
balance: hunter slug damage multiplier 5=>4

### DIFF
--- a/modular_ss220/modules/balance-1984/hunterslug/shotgun.dm
+++ b/modular_ss220/modules/balance-1984/hunterslug/shotgun.dm
@@ -1,0 +1,2 @@
+/obj/projectile/bullet/shotgun_slug/hunter
+	biotype_damage_multiplier = 4

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9294,6 +9294,7 @@
 #include "modular_ss220\modules\balance-1984\simplemobs_slowdown\flesh_spider.dm"
 #include "modular_ss220\modules\balance-1984\simplemobs_slowdown\spider.dm"
 #include "modular_ss220\modules\balance-1984\simplemobs_slowdown\space_dragon.dm"
+#include "modular_ss220\modules\balance-1984\hunterslug\shotgun.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\magazines.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\pistol.dm"
 #include "modular_ss220\modules\security_vouchers\closets\secure\security.dm"


### PR DESCRIPTION
## Changelog

:cl:
balance: Hunter slug damage multiplier for compatible targets 5=>4, base damage still 20
/:cl:

****
- [x] Проверено на локалке
