### PR TITLE
balance: kiboko grenades projectile speed

### DIFF
--- a/modular_ss220/modules/balance-1984/greandes_projectiles/grenade.dm
+++ b/modular_ss220/modules/balance-1984/greandes_projectiles/grenade.dm
@@ -1,0 +1,2 @@
+/obj/projectile/bullet/c980grenade
+	speed = 0.9 // original 0.5 (for nova)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9295,6 +9295,7 @@
 #include "modular_ss220\modules\balance-1984\simplemobs_slowdown\spider.dm"
 #include "modular_ss220\modules\balance-1984\simplemobs_slowdown\space_dragon.dm"
 #include "modular_ss220\modules\balance-1984\hunterslug\shotgun.dm"
+#include "modular_ss220\modules\balance-1984\greandes_projectiles\grenade.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\magazines.dm"
 #include "modular_ss220\modules\sol_pistol_incapacitator\pistol.dm"
 #include "modular_ss220\modules\security_vouchers\closets\secure\security.dm"


### PR DESCRIPTION
## Changelog

:cl:
balance: Kiboko grenades projectiles speed increased 0.5 => 0.9 (normal projectile speed is 1.25)
/:cl:

****
- [x] Проверено на локалке