### PR TITLE
fix: depowered/broken telecomms no longer display NTTC

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -212,7 +212,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	if (!radio_freq || !announcer)
 		return "[namepart]"
 	var/datum/nttc_configuration/nttc = announcer ? announcer.nttc : null
-	if (!nttc) // very weird if it's not exist, as it built-in to announcer
+	if (!nttc || (announcer.machine_stat & (BROKEN|NOPOWER)))
 		return "[namepart]"
 
 	return nttc.compose_ntts_job(raw_message, namepart, announcer, job, job_custom_name, speaker_source)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -212,7 +212,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	if (!radio_freq || !announcer)
 		return "[namepart]"
 	var/datum/nttc_configuration/nttc = announcer ? announcer.nttc : null
-	if (!nttc || (announcer.machine_stat & (BROKEN|NOPOWER)))
+	if (!nttc || (announcer.machine_stat & (BROKEN|NOPOWER|EMPED)))
 		return "[namepart]"
 
 	return nttc.compose_ntts_job(raw_message, namepart, announcer, job, job_custom_name, speaker_source)


### PR DESCRIPTION
## Changelog

:cl:
fix: NTTC at telecomms no longer works if machine is depowered/broken/EMP (comms blackout count as EMP)
/:cl:

****
- [x] Проверено на локалке
