### PR TITLE
add: mapvote highlight options

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -343,6 +343,7 @@ SUBSYSTEM_DEF(vote)
 				"countMethod" = current_vote.count_method,
 				"displayStatistics" = current_vote.display_statistics,
 				"choices" = choices,
+				"choicesHighlight" = current_vote?.choices_highlight, // SS1984 ADDITION
 				"vote" = vote_data,
 			)
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -343,7 +343,7 @@ SUBSYSTEM_DEF(vote)
 				"countMethod" = current_vote.count_method,
 				"displayStatistics" = current_vote.display_statistics,
 				"choices" = choices,
-				"choicesHighlight" = current_vote?.choices_highlight, // SS1984 ADDITION
+				"choicesHighlight" = current_vote.choices_highlight, // SS1984 ADDITION
 				"vote" = vote_data,
 			)
 

--- a/modular_ss220/modules/vote_highlight/map_vote.dm
+++ b/modular_ss220/modules/vote_highlight/map_vote.dm
@@ -1,7 +1,7 @@
 /datum/vote/map_vote
 	choices_highlight = list(
 		"Delta Station",
-		"Metastation",
+		"MetaStation",
 		"Ice Box Station",
 		"Tramstation",
 	)

--- a/modular_ss220/modules/vote_highlight/map_vote.dm
+++ b/modular_ss220/modules/vote_highlight/map_vote.dm
@@ -1,0 +1,7 @@
+/datum/vote/map_vote
+	choices_highlight = list(
+		"Delta Station",
+		"Metastation",
+		"Ice Box Station",
+		"Tramstation",
+	)

--- a/modular_ss220/modules/vote_highlight/vote.dm
+++ b/modular_ss220/modules/vote_highlight/vote.dm
@@ -1,0 +1,2 @@
+/datum/vote
+	var/list/choices_highlight

--- a/modular_ss220/modules/vote_highlight/vote.dm
+++ b/modular_ss220/modules/vote_highlight/vote.dm
@@ -1,2 +1,2 @@
 /datum/vote
-	var/list/choices_highlight
+	var/list/choices_highlight = list()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9329,4 +9329,6 @@
 #include "modular_ss220\modules\security_minor_1984\shoulder_holsters\accessory_actions.dm"
 #include "modular_ss220\modules\security_minor_1984\shoulder_holsters\human_keybindings.dm"
 #include "modular_ss220\modules\security_minor_1984\shoulder_holsters\biogenerator_designs.dm"
+#include "modular_ss220\modules\vote_highlight\vote.dm"
+#include "modular_ss220\modules\vote_highlight\map_vote.dm"
 // END_INCLUDE

--- a/tgui/packages/tgui/interfaces/VotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/VotePanel.tsx
@@ -37,6 +37,7 @@ type ActiveVote = {
   question: string | null;
   timeRemaining: number;
   displayStatistics: boolean;
+  choicesHighlight: string[] | null; // SS1984 ADDITION
   choices: Option[];
   countMethod: number;
 };
@@ -237,6 +238,27 @@ const VotersList = (props) => {
 const ChoicesPanel = (props) => {
   const { act, data } = useBackend<Data>();
   const { currentVote, user } = data;
+  // SS1984 ADDITION START
+  const highlightNames = currentVote.choicesHighlight;
+  if (highlightNames && highlightNames.length > 0) {
+    // Make highlighted options bold
+    currentVote.choices.forEach(option => {
+      if (highlightNames.includes(option.name)) {
+        option.name = `<b>${option.name}</b>`; // Wrap with markdown bold syntax
+      }
+    });
+    // Sort, so highlighted are displayed first
+    currentVote.choices.sort((a, b) => {
+      const aHighlighted = highlightNames.includes(a.name);
+      const bHighlighted = highlightNames.includes(b.name);
+
+      if (aHighlighted === bHighlighted) {
+        return 0; // keep relative order if both highlighted or both non-highlighted
+      }
+      return aHighlighted ? -1 : 1; // highlighted option comes first
+    });
+  }
+  // SS1984 ADDITION END
 
   return (
     <Stack.Item grow>

--- a/tgui/packages/tgui/interfaces/VotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/VotePanel.tsx
@@ -239,24 +239,20 @@ const ChoicesPanel = (props) => {
   const { act, data } = useBackend<Data>();
   const { currentVote, user } = data;
   // SS1984 ADDITION START
-  const highlightNames = currentVote.choicesHighlight;
-  if (highlightNames && highlightNames.length > 0) {
-    // Make highlighted options bold
-    currentVote.choices.forEach(option => {
-      if (highlightNames.includes(option.name)) {
-        option.name = `<b>${option.name}</b>`; // Wrap with markdown bold syntax
-      }
-    });
-    // Sort, so highlighted are displayed first
-    currentVote.choices.sort((a, b) => {
-      const aHighlighted = highlightNames.includes(a.name);
-      const bHighlighted = highlightNames.includes(b.name);
+  if (currentVote && currentVote.choices && currentVote.choices.length > 0) {
+    const highlightNames = currentVote.choicesHighlight;
+    if (highlightNames && highlightNames.length > 0) {
+      // Sort, so highlighted are displayed first
+      currentVote.choices.sort((a, b) => {
+        const aHighlighted = highlightNames.includes(a.name);
+        const bHighlighted = highlightNames.includes(b.name);
 
-      if (aHighlighted === bHighlighted) {
-        return 0; // keep relative order if both highlighted or both non-highlighted
-      }
-      return aHighlighted ? -1 : 1; // highlighted option comes first
-    });
+        if (aHighlighted === bHighlighted) {
+          return 0; // keep relative order if both highlighted or both non-highlighted
+        }
+        return aHighlighted ? -1 : 1; // highlighted option comes first
+      });
+    }
   }
   // SS1984 ADDITION END
 
@@ -273,7 +269,14 @@ const ChoicesPanel = (props) => {
             {currentVote.choices.map((choice) => (
               <Box key={choice.name}>
                 <LabeledList.Item
-                  label={choice.name.replace(/^\w/, (c) => c.toUpperCase())}
+                  // SS1984 REMOVAL label={choice.name.replace(/^\w/, (c) => c.toUpperCase())}
+                  // SS1984 ADDITION START
+                  label={
+                    <span style={{ fontWeight: currentVote.choicesHighlight?.includes(choice.name) ? 'bold' : 'normal' }}>
+                      {choice.name.replace(/^\w/, (c) => c.toUpperCase())}
+                    </span>
+                  }
+                  // SS1984 ADDITION END
                   textAlign="right"
                   buttons={
                     <Button
@@ -320,7 +323,14 @@ const ChoicesPanel = (props) => {
             {currentVote.choices.map((choice) => (
               <Box key={choice.name}>
                 <LabeledList.Item
-                  label={choice.name.replace(/^\w/, (c) => c.toUpperCase())}
+                  // SS1984 REMOVAL label={choice.name.replace(/^\w/, (c) => c.toUpperCase())}
+                  // SS1984 ADDITION START
+                  label={
+                    <span style={{ fontWeight: currentVote.choicesHighlight?.includes(choice.name) ? 'bold' : 'normal' }}>
+                      {choice.name.replace(/^\w/, (c) => c.toUpperCase())}
+                    </span>
+                  }
+                  // SS1984 ADDITION END
                   textAlign="right"
                   buttons={
                     <Button


### PR DESCRIPTION
## Описание



## Changelog

:cl:
add: Map vote now highlight recommended maps (Delta, Meta, Tram, Icebox) - these maps have up-to-date mapping
qol: Highlighted options in vote displayed at top
/:cl:

****
- [x] Проверено на локалке