### PR TITLE
map: secure storage buttons for recommended maps

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -56254,6 +56254,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
+"nVA" = (
+/obj/structure/sign/warning/secure_area,
+/obj/machinery/button/door/directional/west{
+	id = "engstorage";
+	name = "Engineering Secure Storage Control";
+	pixel_x = -8;
+	pixel_y = 8;
+	req_access = list("engine_equip")
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/main)
 "nVB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -124495,7 +124506,7 @@ vvH
 hcQ
 dsj
 rRD
-pgA
+nVA
 hOa
 aGo
 auD

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -59923,6 +59923,16 @@
 /obj/effect/spawner/random/maintenance/no_decals/two,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"qUd" = (
+/obj/machinery/button/door/directional/west{
+	id = "engstorage";
+	name = "Engineering Secure Storage Control";
+	pixel_x = 4;
+	pixel_y = 4;
+	req_access = list("engine_equip")
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/engine_smes)
 "qUf" = (
 /obj/machinery/firealarm/directional/east,
 /obj/item/storage/box/bodybags{
@@ -242664,7 +242674,7 @@ mNY
 yaL
 rqF
 rqF
-yaL
+qUd
 yaL
 yaL
 yaL

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2217,6 +2217,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"aMz" = (
+/obj/machinery/button/door/directional/west{
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	req_access = list("engine_equip");
+	pixel_x = 6
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/main)
 "aMB" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -110431,7 +110440,7 @@ mww
 kEs
 xsd
 uXd
-uXd
+aMz
 hnG
 hnG
 uXd

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -12775,6 +12775,16 @@
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
+"dqk" = (
+/obj/machinery/button/door/directional/west{
+	name = "Engineering Secure Storage";
+	id = "Secure Storage";
+	req_access = list("engine_equip");
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/engine_smes)
 "dqm" = (
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
@@ -101251,7 +101261,7 @@ pkp
 bTm
 bTm
 hRi
-pkp
+dqk
 anu
 voC
 doT


### PR DESCRIPTION
## Скриншоты

### Delta

<img width="1076" height="759" alt="image" src="https://github.com/user-attachments/assets/e0527b72-31ab-4832-bbaa-d42c74943290" />

### Meta

<img width="739" height="461" alt="image" src="https://github.com/user-attachments/assets/0222291c-0ecc-4dea-91a4-46f1a19d92bd" />

### Icebox

<img width="857" height="579" alt="image" src="https://github.com/user-attachments/assets/245b0936-ba68-4f6a-9d3e-a20f2ab8cd85" />

### Tram

<img width="554" height="417" alt="image" src="https://github.com/user-attachments/assets/a577f5a8-8b0d-4f73-85b0-a6baf6097072" />

## Changelog

:cl:
map: Engineering Secure Storage button is added to all recommended maps (delta, meta, icebox, tram)
/:cl:

****
- [x] Проверено на локалке