### PR TITLE
map: added oxygen canister to armory on recommended maps

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -7558,6 +7558,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "bOU" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -29722,6 +29722,7 @@
 /area/station/service/bar/atrium)
 "iuS" = (
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/security/armory/upper)
 "ivi" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29141,6 +29141,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "kaF" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -26155,6 +26155,7 @@
 	pixel_x = 23;
 	pixel_y = -8
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "irv" = (


### PR DESCRIPTION
## Скриншоты

### Delta

<img width="654" height="715" alt="image" src="https://github.com/user-attachments/assets/d0876f34-29d7-483f-a45c-918f5d7ab890" />

### Meta

<img width="727" height="666" alt="image" src="https://github.com/user-attachments/assets/541d814b-8f53-4bc2-bdf2-24a11a4fbf44" />

### Icebox

<img width="739" height="719" alt="image" src="https://github.com/user-attachments/assets/c68050fa-aa78-4f67-9a1f-67af0c65ec1a" />

### Tram

<img width="792" height="793" alt="image" src="https://github.com/user-attachments/assets/4f3cee68-20c6-4f91-b6fd-6dcb360536d9" />

## Changelog

:cl:
map: Added oxygen canister to armory on recommended maps (Delta, Meta, Icebox, Tram)
/:cl:

****
- [x] Проверено на локалке
