### PR TITLE
qol: PDA now shows message on shutdown by powerloss

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -54,7 +54,10 @@
 		if(open_programs in idle_threads)
 			power_usage += (open_programs.power_cell_use / 2)
 
+	var/old_charge = internal_cell?.charge // SS1984 ADDITION
 	if(use_energy(power_usage * seconds_per_tick))
+		if (internal_cell && internal_cell.charge <= 0 && old_charge != internal_cell.charge) // SS1984 ADDITION
+			power_failure() // SS1984 ADDITION
 		return TRUE
 	power_failure()
 	return FALSE

--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -37,7 +37,7 @@
 		set_light_on(FALSE)
 	for(var/datum/computer_file/program/programs as anything in idle_threads)
 		programs.event_powerfailure()
-	shutdown_computer(loud = FALSE)
+	shutdown_computer(loud = TRUE) // SS1984 EDIT, original: shutdown_computer(loud = FALSE)
 
 ///Takes the charge necessary from the Computer, shutting it off if it's unable to provide it.
 ///Charge depends on whether the PC is on, and what programs are running/idle on it.


### PR DESCRIPTION
## Changelog

:cl:
qol: Modular computers (PDA) now shows message when shutdown by powerloss
code: Modular computers (PDA) powerloss now triggering itself when cell charge's ends
/:cl:

****
- [x] Проверено на локалке
