### PR TITLE
map: unica at hos safe in recommended maps

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -26660,12 +26660,19 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "gxW" = (
-/obj/structure/dresser,
 /obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 10
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/safe{
+	known_by = list("hos")
+	},
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/clothing/accessory/holster,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hos)
 "gxX" = (
@@ -70430,6 +70437,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/item/flashlight/lamp/green,
+/obj/item/paper/paperslip/corporate/fluff/safe_code{
+	owner = "hos"
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hos)
 "rwM" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -18011,29 +18011,15 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - HoS Office"
 	},
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 16;
-	start_on = 0
-	},
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/item/stamp/head/hos{
-	pixel_x = 10;
-	pixel_y = 6
-	},
-/obj/machinery/recharger{
-	pixel_x = -4;
-	pixel_y = -1
-	},
 /obj/machinery/airalarm/directional/west,
-/obj/item/phone{
-	pixel_x = -9;
-	pixel_y = 7
+/obj/structure/safe{
+	known_by = list("hos")
 	},
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/clothing/accessory/holster,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hos)
 "faf" = (
@@ -54401,8 +54387,8 @@
 	pixel_y = 20
 	},
 /obj/item/taperecorder{
-	pixel_x = -5;
-	pixel_y = 1
+	pixel_x = -10;
+	pixel_y = 6
 	},
 /obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
 	pixel_x = 7;
@@ -54415,6 +54401,14 @@
 /obj/structure/secure_safe/hos{
 	pixel_x = 28;
 	pixel_y = 6
+	},
+/obj/machinery/recharger{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/paper/paperslip/corporate/fluff/safe_code{
+	owner = "hos";
+	pixel_y = 10
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/hos)
@@ -74224,6 +74218,23 @@
 	},
 /obj/item/radio/off{
 	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/stamp/head/hos{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/item/paper_bin{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = -6;
+	pixel_y = 16;
+	start_on = 0
+	},
+/obj/item/phone{
+	pixel_x = -9;
 	pixel_y = 7
 	},
 /turf/open/floor/wood/large,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -16659,6 +16659,13 @@
 	pixel_y = 6
 	},
 /obj/item/stamp/head/hos,
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/paper/paperslip/corporate/fluff/safe_code{
+	owner = "hos"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "fTe" = (
@@ -17309,20 +17316,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "gfk" = (
-/obj/structure/table/wood,
-/obj/item/phone{
-	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/cigbutt/cigarbutt{
-	pixel_x = 5;
-	pixel_y = -1
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/safe{
+	known_by = list("hos")
+	},
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/clothing/accessory/holster,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "gfU" = (
@@ -46241,6 +46246,11 @@
 /obj/machinery/button/door/directional/west{
 	id = "hosprivacy";
 	name = "Privacy Shutters Control"
+	},
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -5927,16 +5927,14 @@
 /turf/open/space/openspace,
 /area/station/solars/starboard/fore)
 "aUa" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -5
+/obj/structure/safe{
+	known_by = list("hos")
 	},
-/obj/item/taperecorder{
-	pixel_x = -5
-	},
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/clothing/accessory/holster,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "aUb" = (
@@ -13608,17 +13606,18 @@
 /area/station/hallway/secondary/entry)
 "dFI" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/seccarts{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/storage/box/deputy,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/button/door/directional/west{
 	name = "Emergency Blast Doors";
 	pixel_y = -8;
 	id = "HOSOffice";
 	req_access = list("hos")
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/item/paper/paperslip/corporate/fluff/safe_code{
+	owner = "hos"
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
@@ -46289,6 +46288,9 @@
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/stamp/head/hos,
+/obj/item/taperecorder{
+	pixel_x = -5
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "ptD" = (
@@ -66943,6 +66945,14 @@
 	pixel_x = -3;
 	pixel_y = 8;
 	start_on = 0
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -5
+	},
+/obj/item/storage/box/deputy,
+/obj/item/storage/box/seccarts{
+	pixel_x = 3;
+	pixel_y = 2
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)


### PR DESCRIPTION
## Скриншоты

### Delta

<img width="544" height="729" alt="image" src="https://github.com/user-attachments/assets/0fb4f89e-2b17-4c1b-b954-5f8ee6bddc05" />

### Meta

<img width="856" height="756" alt="image" src="https://github.com/user-attachments/assets/c862754d-9294-427f-8530-66b3076e31a0" />

### Icebox

<img width="646" height="761" alt="image" src="https://github.com/user-attachments/assets/2ed24dcb-57c9-4517-952d-fab7513bdeb6" />

### Tram

<img width="850" height="653" alt="image" src="https://github.com/user-attachments/assets/0feadb56-fefe-4477-a0b9-4b7d7ee6a0b1" />

## Changelog

:cl:
map: Added safe to HOS office with unica-6 in it with 3 speedloaders + holster for all recommended maps (Delta, Meta, Icebox, Tram)
map: Added safe codes to HOS office for all recommended maps (Delta, Meta, Icebox, Tram)
/:cl:

****
- [x] Проверено на локалке
