### PR TITLE
Revert "[Removal] Removes 'His Grace' from traitor uplink.  (#5777)"

### DIFF
--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -300,7 +300,6 @@
 	car.visible_message(span_notice("[key] drops out of [car] onto the floor."))
 	return car
 
-/* NOVA EDIT REMOVAL START - DISABLED
 /datum/uplink_item/role_restricted/his_grace
 	name = "His Grace"
 	desc = "An incredibly dangerous weapon recovered from a station overcome by the grey tide. Once activated, He will thirst for blood and must be used to kill to sate that thirst. \
@@ -314,7 +313,6 @@
 	surplus = 0
 	restricted_roles = list(JOB_CHAPLAIN)
 	purchasable_from = ~UPLINK_SPY
-*/ // NOVA EDIT REMOVAL END
 
 /datum/uplink_item/role_restricted/concealed_weapon_bay
 	name = "Concealed Weapon Bay"


### PR DESCRIPTION
This reverts commit 51e99e2901221d3da0748ac4e7081783982aa4d8.

## Changelog

:cl:
add: Revert: Removed 'His Grace' from the Traitor uplink. It was a chaplain traitor only item that required you to consume 25 player corpses to ascend, making you inmune to stuns, regen life and putting you in a timer to kill as many people possible. (upstream #5777)
/:cl:
