### PR TITLE
add: cryo message wake up instead of default arrival when spawn on cryo

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -241,6 +241,10 @@
 		var/area/player_area = get_area(character)
 		deadchat_broadcast(span_game(" has arrived at the station at [span_name(player_area.name)]."), span_game("[span_name(character.real_name)] ([rank])"), follow_target = character, message_type=DEADCHAT_ARRIVALRATTLE)
 	if(character.mind && (character.mind.assigned_role.job_flags & JOB_ANNOUNCE_ARRIVAL))
+		// SS1984 ADDITION START
+		if (try_show_cryomessage_for_spawn(character, rank))
+			return
+		// SS1984 ADDITION END
 		aas_config_announce(/datum/aas_config_entry/arrival, list("PERSON" = character.real_name,"RANK" = rank))
 
 ///Check if the turf pressure allows specialized equipment to work

--- a/modular_ss220/modules/cryo_spawnmessages/__HELPERS_cryojoin.dm
+++ b/modular_ss220/modules/cryo_spawnmessages/__HELPERS_cryojoin.dm
@@ -1,0 +1,32 @@
+/proc/try_show_cryomessage_for_spawn(mob/living/carbon/human/character, rank)
+	if (!character)
+		return FALSE
+	var/turf/tile = get_turf(character)
+	if(!isturf(tile))
+		return FALSE
+	var/obj/machinery/cryopod/cryo_pod_instance
+	for(var/obj/machinery/cryopod/cryo_pod in tile)
+		if (!cryo_pod)
+			continue
+		cryo_pod_instance = cryo_pod
+		break
+	if (!cryo_pod_instance)
+		return FALSE
+	var/area/cryo_pod_area = get_area(cryo_pod_instance)
+	if (!cryo_pod_area)
+		return FALSE
+	var/obj/machinery/computer/cryopod/control_comp
+	for(var/cryo_console as anything in GLOB.cryopod_computers)
+		var/obj/machinery/computer/cryopod/console = cryo_console
+		var/area/console_area = get_area(cryo_console)
+		if(console_area == cryo_pod_area)
+			control_comp = console
+			break
+	if (!control_comp)
+		return FALSE
+
+	var/occupant_departments_bitflags = character.mind?.assigned_role.departments_bitflags
+	var/occupant_job_radio = character.mind?.assigned_role.default_radio_channel
+
+	control_comp.announce("CRYO_JOIN", character.real_name, rank, occupant_departments_bitflags, occupant_job_radio)
+	return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -637,6 +637,7 @@
 #include "code\__HELPERS\~nova_helpers\unsorted.dm"
 #include "modular_ss220\modules\enhanced_messaging\__HELPERS\job_helper.dm"
 #include "modular_ss220\modules\security_minor_1984\__HELPERS\text.dm"
+#include "modular_ss220\modules\cryo_spawnmessages\__HELPERS_cryojoin.dm"
 #include "code\_globalvars\_regexes.dm"
 #include "code\_globalvars\admin.dm"
 #include "code\_globalvars\arcade.dm"


### PR DESCRIPTION
## Changelog

:cl:
add: Now displays cryo wake up message when spawned on cryo pod, instead of default arrival message
/:cl:

****
- [x] Проверено на локалке