### PR TITLE
add: Prisoners latejoin spawn at cryo in permabrig instead of air

### DIFF
--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -44,8 +44,9 @@
 	var/datum/prisoner_crime/crime = GLOB.prisoner_crimes[crime_name]
 	var/datum/crime/past_crime = new(crime.name, crime.desc, "Central Command", "Indefinite.")
 	var/datum/record/crew/target_record = find_record(crewmember.real_name)
-	target_record.crimes += past_crime
-	target_record.recreate_manifest_photos(add_height_chart = TRUE)
+	if (target_record) // SS1984 ADDITION
+		target_record.crimes += past_crime
+		target_record.recreate_manifest_photos(add_height_chart = TRUE)
 	to_chat(crewmember, span_warning("You are imprisoned for \"[crime_name]\"."))
 	crewmember.add_mob_memory(/datum/memory/key/permabrig_crimes, crimes = crime_name)
 

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -44,9 +44,8 @@
 	var/datum/prisoner_crime/crime = GLOB.prisoner_crimes[crime_name]
 	var/datum/crime/past_crime = new(crime.name, crime.desc, "Central Command", "Indefinite.")
 	var/datum/record/crew/target_record = find_record(crewmember.real_name)
-	if (target_record) // SS1984 ADDITION
-		target_record.crimes += past_crime
-		target_record.recreate_manifest_photos(add_height_chart = TRUE)
+	target_record.crimes += past_crime
+	target_record.recreate_manifest_photos(add_height_chart = TRUE)
 	to_chat(crewmember, span_warning("You are imprisoned for \"[crime_name]\"."))
 	crewmember.add_mob_memory(/datum/memory/key/permabrig_crimes, crimes = crime_name)
 

--- a/modular_ss220/modules/security_minor_1984/prisoner_spawnpoints/prisoner.dm
+++ b/modular_ss220/modules/security_minor_1984/prisoner_spawnpoints/prisoner.dm
@@ -1,0 +1,28 @@
+/datum/job/prisoner/get_latejoin_spawn_point()
+	. = ..()
+	var/turf/spawn_point_original = .
+	if (!spawn_point_original)
+		return .
+	var/turf/spawn_point
+	var/list/turf/possible_turfs = list()
+	for(var/obj/machinery/cryopod/prison/cryo_pod as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/cryopod/prison))
+		if (!cryo_pod)
+			continue
+
+		var/area/cryopod_area = get_area(cryo_pod)
+		if (!cryopod_area || !istype(cryopod_area, /area/station/security/prison))
+			continue
+
+		var/turf/cryopod_turf = get_turf(cryo_pod)
+		if (!cryopod_turf)
+			continue
+
+		possible_turfs += cryopod_turf
+
+	if (length(possible_turfs) < 1)
+		return .
+
+	spawn_point = pick(possible_turfs)
+
+	. = spawn_point ? spawn_point : spawn_point_original
+	return .

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9389,6 +9389,7 @@
 #include "modular_ss220\modules\security_minor_1984\shoulder_holsters\human_keybindings.dm"
 #include "modular_ss220\modules\security_minor_1984\shoulder_holsters\biogenerator_designs.dm"
 #include "modular_ss220\modules\security_minor_1984\detective_analyzer_closets\security.dm"
+#include "modular_ss220\modules\security_minor_1984\prisoner_spawnpoints\prisoner.dm"
 #include "modular_ss220\modules\vote_highlight\vote.dm"
 #include "modular_ss220\modules\vote_highlight\map_vote.dm"
 #include "modular_ss220\modules\plasma_inflation\plasma_defines.dm"


### PR DESCRIPTION
## Changelog

:cl:
add: Prisoners latejoin spawns at cryopods in permabrig, instead of appearing from nowhere
/:cl:

****
- [x] Проверено на локалке
