### PR TITLE
code: Hide bridge officer from id painter and id templates

### DIFF
--- a/code/__DEFINES/~ss1984_defines/job.dm
+++ b/code/__DEFINES/~ss1984_defines/job.dm
@@ -1,0 +1,4 @@
+#define TRIM_HIDE_NONE 0
+#define TRIM_HIDE_STATION 1
+#define TRIM_HIDE_CENTCOMM 2
+#define TRIM_HIDE_ALL 3

--- a/code/controllers/subsystem/networks/id_access.dm
+++ b/code/controllers/subsystem/networks/id_access.dm
@@ -31,8 +31,6 @@ SUBSYSTEM_DEF(id_access)
 	var/list/station_pda_templates = list()
 	/// Helper list containing all station regions.
 	var/list/station_regions = list()
-	/// Contains all station trims, but not nt rep		// SS1984 ADDITION
-	var/list/station_job_templates_no_ntr = list()		// SS1984 ADDITION
 
 	/// The roundstart generated code for the spare ID safe. This is given to the Captain on shift start. If there's no Captain, it's given to the HoP. If there's no HoP
 	var/spare_id_safe_code = ""
@@ -217,6 +215,8 @@ SUBSYSTEM_DEF(id_access)
 		var/datum/id_trim/job/trim = trim_singletons_by_path[trim_path]
 		if(!length(trim.template_access))
 			continue
+		if (trim.hide_in_templates > TRIM_HIDE_NONE) // SS1984 ADDITION
+			continue // SS1984 ADDITION
 
 		station_job_templates[trim_path] = trim.assignment
 		for(var/access in trim.template_access)
@@ -227,26 +227,16 @@ SUBSYSTEM_DEF(id_access)
 				continue
 			var/list/templates = manager["templates"]
 			templates[trim_path] = trim.assignment
-// SS1984 ADDITION START
-	var/list/station_job_trims_no_ntr = subtypesof(/datum/id_trim/job) - (/datum/id_trim/job/nanotrasen_consultant)
-	for(var/trim_path in station_job_trims_no_ntr)
-		var/datum/id_trim/job/trim = trim_singletons_by_path[trim_path]
-		if(!length(trim.template_access))
-			continue
 
-		station_job_templates_no_ntr[trim_path] = trim.assignment
-		for(var/access in trim.template_access)
-			var/list/manager = sub_department_managers_tgui["[access]"]
-			if(!manager)
-				if(access != ACCESS_CHANGE_IDS)
-					WARNING("Invalid template access access \[[access]\] registered with [trim_path]. Template added to global list anyway.")
-				continue
-			var/list/templates = manager["templates"]
-			templates[trim_path] = trim.assignment
-// SS1984 ADDITION END
 	var/list/centcom_job_trims = typesof(/datum/id_trim/centcom) - typesof(/datum/id_trim/centcom/corpse) + (/datum/id_trim/job/nanotrasen_consultant)	// SS1984 EDIT ORIGINAL var/list/centcom_job_trims = typesof(/datum/id_trim/centcom) - typesof(/datum/id_trim/centcom/corpse)
 	for(var/trim_path in centcom_job_trims)
 		var/datum/id_trim/trim = trim_singletons_by_path[trim_path]
+		// SS1984 ADDITION START
+		if (istype(trim, /datum/id_trim/job))
+			var/datum/id_trim/job/trim_job = trim
+			if (trim_job.hide_in_templates > TRIM_HIDE_STATION)
+				continue
+		// SS1984 ADDITION END
 		centcom_job_templates[trim_path] = trim.assignment
 
 	var/list/all_pda_paths = typesof(/obj/item/modular_computer/pda)

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -60,13 +60,13 @@
 			valid_access = SSid_access.get_region_access_list(list(REGION_CENTCOM))
 		else if((is_centcom) && ((ACCESS_CENT_LIVING in auth_card.access)))
 			centcom_minor = TRUE
-			job_templates = SSid_access.station_job_templates_no_ntr.Copy()
+			job_templates = SSid_access.station_job_templates.Copy()
 			valid_access = SSid_access.get_region_access_list(list(REGION_NTR))
 		else if(is_centcom)
 			return FALSE
 		else
 			centcom_minor = FALSE
-			job_templates = SSid_access.station_job_templates_no_ntr.Copy()
+			job_templates = SSid_access.station_job_templates.Copy()
 			valid_access = SSid_access.get_region_access_list(list(REGION_ALL_STATION))	// SS1984 ADDITION END
 		computer.update_static_data_for_all_viewers()
 		return TRUE

--- a/modular_ss220/modules/forbid_imprint_trim/job.dm
+++ b/modular_ss220/modules/forbid_imprint_trim/job.dm
@@ -1,0 +1,5 @@
+/datum/id_trim/job
+	var/hide_in_templates = TRIM_HIDE_NONE
+
+/datum/id_trim/job/bridge_assistant
+	hide_in_templates = TRIM_HIDE_STATION

--- a/modular_ss220/modules/rolesedit/code/jobs/ntr.dm
+++ b/modular_ss220/modules/rolesedit/code/jobs/ntr.dm
@@ -120,6 +120,7 @@
 	job = /datum/job/nanotrasen_consultant
 	big_pointer = TRUE
 	pointer_color = COLOR_CENTCOM_BLUE
+	hide_in_templates = TRIM_HIDE_STATION
 
 /datum/outfit/job/nanotrasen_consultant
 	name = "Nanotrasen Consultant"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -513,6 +513,7 @@
 #include "code\__DEFINES\~nova_defines\_HELPERS\offset_index.dm"
 #include "code\__DEFINES\~nova_defines\traits\declarations.dm"
 #include "code\__DEFINES\~ss1984_defines\prisoner.dm"
+#include "code\__DEFINES\~ss1984_defines\job.dm"
 #include "code\__HELPERS\_auxtools_api.dm"
 #include "code\__HELPERS\_dreamluau.dm"
 #include "code\__HELPERS\_lists.dm"
@@ -9404,4 +9405,5 @@
 #include "modular_ss220\modules\localization_modular\ert.dm"
 #include "modular_ss220\modules\changelog_highlight\changelog_highlight.dm"
 #include "modular_ss220\modules\changelog_highlight\changelog.dm"
+#include "modular_ss220\modules\forbid_imprint_trim\job.dm"
 // END_INCLUDE


### PR DESCRIPTION
## Changelog

:cl:
del: Removed bridge officer from id painter and non-centcom console ID templates
/:cl:

****
- [x] Проверено на локалке