### PR TITLE
add: colored pda manifest

### DIFF
--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -28,6 +28,10 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 	// First we build up the order in which we want the departments to appear in.
 	var/list/manifest_out = list()
 	for(var/datum/job_department/department as anything in SSjob.joinable_departments)
+		// SS1984 ADDITION START, silicons ARE NOT CREW
+		if(department.department_name == DEPARTMENT_SILICON)
+			continue
+		// SS1984 ADDITION END
 		manifest_out[department.department_name] = list()
 	manifest_out[DEPARTMENT_UNASSIGNED] = list()
 
@@ -36,6 +40,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 		var/name = target.name
 		var/rank = target.rank // user-visible job
 		var/trim = target.trim // internal jobs by trim type
+		var/active_status = target.physical_status // SS1984 ADDITION
 		// NOVA EDIT ADDITION START - bare minimum data the station records need to possess to show up on the crew manifest
 		if((name == "Unknown") || (rank == "Unassigned" || rank == "Unknown")) // records are unassigned by default, but if edited without input becomes unknown
 			continue
@@ -47,6 +52,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 				"name" = name,
 				"rank" = rank,
 				"trim" = trim,
+				"active" = active_status, // SS1984 ADDITION
 				)
 			continue
 		for(var/department_type as anything in job.departments_list)
@@ -61,8 +67,16 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 				"name" = name,
 				"rank" = rank,
 				"trim" = trim,
+				"active" = active_status,  // SS1984 ADDITION
 				)
-			var/list/department_list = manifest_out[department.department_name]
+			// SS1984 ADDITION START, treat central command (put blueshields and all that stuff to command)
+			var/department_key = department.department_name
+			if(department_key == DEPARTMENT_CENTRAL_COMMAND)
+				department_key = "command"
+			if(trim == "Silicon" || department_key == "Silicon") // no silicons in CREW manifest
+				continue
+			// SS1984 ADDITION END
+			var/list/department_list = manifest_out[department_key] // SS1984 EDIT, original: var/list/department_list = manifest_out[department.department_name]
 			if(istype(job, department.department_head))
 				department_list.Insert(1, null)
 				department_list[1] = entry

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -28,8 +28,8 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 	// First we build up the order in which we want the departments to appear in.
 	var/list/manifest_out = list()
 	for(var/datum/job_department/department as anything in SSjob.joinable_departments)
-		// SS1984 ADDITION START, silicons ARE NOT CREW
-		if(department.department_name == DEPARTMENT_SILICON)
+		// SS1984 ADDITION START
+		if(department.department_name == DEPARTMENT_SILICON || department.department_name == DEPARTMENT_CENTRAL_COMMAND)
 			continue
 		// SS1984 ADDITION END
 		manifest_out[department.department_name] = list()
@@ -69,12 +69,12 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 				"trim" = trim,
 				"active" = active_status,  // SS1984 ADDITION
 				)
-			// SS1984 ADDITION START, treat central command (put blueshields and all that stuff to command)
+			// SS1984 ADDITION START
 			var/department_key = department.department_name
-			if(department_key == DEPARTMENT_CENTRAL_COMMAND)
-				department_key = "command"
-			if(trim == "Silicon" || department_key == "Silicon") // no silicons in CREW manifest
-				continue
+			if(trim == DEPARTMENT_SILICON || department_key == DEPARTMENT_SILICON)
+				continue // no silicons in CREW manifest
+			if(trim == DEPARTMENT_CENTRAL_COMMAND || department_key == DEPARTMENT_CENTRAL_COMMAND)
+				continue // don't show them as "central command", only to other departments (command)
 			// SS1984 ADDITION END
 			var/list/department_list = manifest_out[department_key] // SS1984 EDIT, original: var/list/department_list = manifest_out[department.department_name]
 			if(istype(job, department.department_head))

--- a/modular_ss220/modules/crew_manifest_colored/crewmanifest.dm
+++ b/modular_ss220/modules/crew_manifest_colored/crewmanifest.dm
@@ -1,7 +1,2 @@
 /datum/computer_file/program/crew_manifest
 	tgui_id = "NtosCrewManifest1984"
-
-// /datum/computer_file/program/crew_manifest/ui_static_data(mob/user)
-// 	var/list/data = list()
-// 	data["manifest"] = GLOB.manifest.get_manifest()
-// 	return data

--- a/modular_ss220/modules/crew_manifest_colored/crewmanifest.dm
+++ b/modular_ss220/modules/crew_manifest_colored/crewmanifest.dm
@@ -1,0 +1,7 @@
+/datum/computer_file/program/crew_manifest
+	tgui_id = "NtosCrewManifest1984"
+
+// /datum/computer_file/program/crew_manifest/ui_static_data(mob/user)
+// 	var/list/data = list()
+// 	data["manifest"] = GLOB.manifest.get_manifest()
+// 	return data

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9420,4 +9420,5 @@
 #include "modular_ss220\modules\extended_smes\machine_circuitboards.dm"
 #include "modular_ss220\modules\extended_smes\smes.dm"
 #include "modular_ss220\modules\upstream-fixes\scarring_rejuve\human_helpers.dm"
+#include "modular_ss220\modules\crew_manifest_colored\crewmanifest.dm"
 // END_INCLUDE

--- a/tgui/packages/tgui/constants.ts
+++ b/tgui/packages/tgui/constants.ts
@@ -33,6 +33,7 @@ export const COLORS = {
     other: '#c38312',
     prisoner: '#FFC2C2', // NOVA EDIT ADDITION
     command: '#F6F743', // SS1984 ADDITION
+    medical: '#3498db', // SS1984 ADDITION
   },
   // Damage type colors
   damageType: {

--- a/tgui/packages/tgui/constants.ts
+++ b/tgui/packages/tgui/constants.ts
@@ -32,6 +32,7 @@ export const COLORS = {
     centcom: '#00c100',
     other: '#c38312',
     prisoner: '#FFC2C2', // NOVA EDIT ADDITION
+    command: '#F6F743', // SS1984 ADDITION
   },
   // Damage type colors
   damageType: {

--- a/tgui/packages/tgui/interfaces/CrewManifestSS1984.tsx
+++ b/tgui/packages/tgui/interfaces/CrewManifestSS1984.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Box, Section, Table } from 'tgui-core/components';
 import { decodeHtmlEntities } from 'tgui-core/string';
 
-import { useBackend } from '../backend';
 import { COLORS } from '../constants';
 
 const deptCols = COLORS.department;
@@ -46,44 +45,44 @@ const HBC = (role: string): boolean => {
 export const ManifestTable = ({ group, department }) => {
   if (group.length === 0) return null;
 
-  const deptColor = deptCols[(department ?? '').toLowerCase()] ?? 'transparent';
-
   return (
     <Table>
-      <Table.Row header style={{ backgroundColor: deptColor }} color="white">
+        <Table.Row header color="white">
         <Table.Cell width="50%">Name</Table.Cell>
         <Table.Cell width="35%">Rank</Table.Cell>
         <Table.Cell width="15%">Active</Table.Cell>
-      </Table.Row>
-      {group.map((person) => (
-        <Table.Row
-          color={HCC(person.rank)}
-          key={`${person.name}-${person.rank}`}
-          bold={HBC(person.rank)}
-          style={{ borderLeft: `6px solid ${deptColor}` }} // example styling to highlight dept color per row
-        >
-          <Table.Cell>{decodeHtmlEntities(person.name)}</Table.Cell>
-          <Table.Cell>{decodeHtmlEntities(person.rank)}</Table.Cell>
-          <Table.Cell>{person.active}</Table.Cell>
         </Table.Row>
-      ))}
+        {group.map((person) => (
+        <Table.Row
+            color={HCC(person.rank)}
+            key={`${person.name}-${person.rank}`}
+            bold={HBC(person.rank)}
+        >
+            <Table.Cell>{decodeHtmlEntities(person.name)}</Table.Cell>
+            <Table.Cell>{decodeHtmlEntities(person.rank)}</Table.Cell>
+            <Table.Cell>{person.active}</Table.Cell>
+        </Table.Row>
+        ))}
     </Table>
-  );
+    );
 };
 
-export const CrewManifestSS1984 = () => {
-  const { act, data: backendData } = useBackend<{ manifest: Manifest }>();
-  const manifest: Manifest = backendData?.manifest ?? {
-    crew: [],
-  };
-
+export const CrewManifestSS1984 = ({ manifest }) => {
+  if (!manifest) return null;
   return (
     <>
-      {Object.entries(manifest).map(([department, group]) => (
-        <Section key={department} title={<Box>{department}</Box>}>
-          <ManifestTable group={group} />
-        </Section>
-      ))}
+      {Object.entries(manifest).map(([department, group]) => {
+        const deptColor = deptCols[(department ?? '').toLowerCase()] ?? 'white';
+
+        return (
+            <Section
+            key={department}
+            title={<Box style={{ color: deptColor, fontWeight: 'bold' }}>{department}</Box>}
+            >
+            <ManifestTable group={group} department={department} />
+            </Section>
+        );
+        })}
     </>
   );
 };

--- a/tgui/packages/tgui/interfaces/CrewManifestSS1984.tsx
+++ b/tgui/packages/tgui/interfaces/CrewManifestSS1984.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Box, Section, Table } from 'tgui-core/components';
+import { decodeHtmlEntities } from 'tgui-core/string';
+
+import { useBackend } from '../backend';
+import { COLORS } from '../constants';
+
+const deptCols = COLORS.department;
+
+const HeadRoles: string[] = [
+  'Captain',
+  'Head of Security',
+  'Chief Engineer',
+  'Chief Medical Officer',
+  'Research Director',
+  'Head of Personnel',
+  'Quartermaster',
+  'Nanotrasen Consultant',
+];
+
+// Types for a person in the manifest
+export interface Person {
+  name: string;
+  rank: string;
+  active: string;
+}
+
+// Type for the manifest object with each department as array of Person
+export interface Manifest {
+  [departmentName: string]: Person[];
+}
+
+// Head colour check
+const HCC = (role: string): string => {
+  if (HeadRoles.includes(role)) {
+    return 'green';
+  }
+  return 'orange';
+};
+
+// Head bold check
+const HBC = (role: string): boolean => {
+  return HeadRoles.includes(role);
+};
+
+export const ManifestTable = ({ group, department }) => {
+  if (group.length === 0) return null;
+
+  const deptColor = deptCols[(department ?? '').toLowerCase()] ?? 'transparent';
+
+  return (
+    <Table>
+      <Table.Row header style={{ backgroundColor: deptColor }} color="white">
+        <Table.Cell width="50%">Name</Table.Cell>
+        <Table.Cell width="35%">Rank</Table.Cell>
+        <Table.Cell width="15%">Active</Table.Cell>
+      </Table.Row>
+      {group.map((person) => (
+        <Table.Row
+          color={HCC(person.rank)}
+          key={`${person.name}-${person.rank}`}
+          bold={HBC(person.rank)}
+          style={{ borderLeft: `6px solid ${deptColor}` }} // example styling to highlight dept color per row
+        >
+          <Table.Cell>{decodeHtmlEntities(person.name)}</Table.Cell>
+          <Table.Cell>{decodeHtmlEntities(person.rank)}</Table.Cell>
+          <Table.Cell>{person.active}</Table.Cell>
+        </Table.Row>
+      ))}
+    </Table>
+  );
+};
+
+export const CrewManifestSS1984 = () => {
+  const { act, data: backendData } = useBackend<{ manifest: Manifest }>();
+  const manifest: Manifest = backendData?.manifest ?? {
+    crew: [],
+  };
+
+  return (
+    <>
+      {Object.entries(manifest).map(([department, group]) => (
+        <Section key={department} title={<Box>{department}</Box>}>
+          <ManifestTable group={group} />
+        </Section>
+      ))}
+    </>
+  );
+};

--- a/tgui/packages/tgui/interfaces/NtosCrewManifest1984.tsx
+++ b/tgui/packages/tgui/interfaces/NtosCrewManifest1984.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Box, Button, Section } from 'tgui-core/components';
+
+import { useBackend } from '../backend';
+import { NtosWindow } from '../layouts';
+import { Manifest, ManifestTable } from './CrewManifestSS1984';
+
+type Data = {
+  manifest: Manifest;
+};
+
+export const NtosCrewManifest1984 = (props) => {
+  const { act, data } = useBackend<Data>();
+  const { manifest = {} as Manifest } = data ?? {};
+  return (
+    <NtosWindow width={500} height={480}>
+      <NtosWindow.Content scrollable>
+        <Section
+          title="Crew Manifest"
+          buttons={
+            <Button
+              icon="print"
+              onClick={() => act('PRG_print')}
+            >
+                Print
+            </Button>
+          }
+        >
+          {Object.entries(manifest).map(([department, group]) => (
+            <Section key={department} title={<Box>{department}</Box>}>
+                <ManifestTable group={group} department={department} />
+            </Section>
+            ))}
+        </Section>
+      </NtosWindow.Content>
+    </NtosWindow>
+  );
+};

--- a/tgui/packages/tgui/interfaces/NtosCrewManifest1984.tsx
+++ b/tgui/packages/tgui/interfaces/NtosCrewManifest1984.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Box, Button, Section } from 'tgui-core/components';
+import { Button, Section } from 'tgui-core/components';
 
 import { useBackend } from '../backend';
 import { NtosWindow } from '../layouts';
-import { Manifest, ManifestTable } from './CrewManifestSS1984';
+import { CrewManifestSS1984, Manifest } from './CrewManifestSS1984';
 
 type Data = {
   manifest: Manifest;
@@ -11,7 +11,7 @@ type Data = {
 
 export const NtosCrewManifest1984 = (props) => {
   const { act, data } = useBackend<Data>();
-  const { manifest = {} as Manifest } = data ?? {};
+  const { manifest } = data;
   return (
     <NtosWindow width={500} height={480}>
       <NtosWindow.Content scrollable>
@@ -26,11 +26,7 @@ export const NtosCrewManifest1984 = (props) => {
             </Button>
           }
         >
-          {Object.entries(manifest).map(([department, group]) => (
-            <Section key={department} title={<Box>{department}</Box>}>
-                <ManifestTable group={group} department={department} />
-            </Section>
-            ))}
+          <CrewManifestSS1984 manifest={manifest} />
         </Section>
       </NtosWindow.Content>
     </NtosWindow>


### PR DESCRIPTION
P.S. манифест через Show Manifest не затронут (за исключением удаления силиконов и ЦК из него)
P.S. (2): "Print" манифеста по прежнему черно-белый, так и задумано. ПДА не цветной принтер.

## Скриншоты

<img width="1060" height="1779" alt="image" src="https://github.com/user-attachments/assets/636066b7-84ea-4c90-9c11-460ee1fdd6e1" />

## Changelog

:cl:
add: Colored PDA manifest
add: Now shows physical status in crew manifest, according to medical records such as Active/Deceased
add: Departments are colored in PDA manifest
del: Crew manifest no longer contains any silicons (they are NOT crew)
del: Crew manifest no longer contains any "Central Command" (blueshield, consultant, and other such are placed in "Command")
/:cl:

****
- [x] Проверено на локалке
