### PR TITLE
fix: hud's no longer can change status from bitrun areas

### DIFF
--- a/modular_ss220/modules/fixes_minor_1984/no_bitrun_huduse/human.dm
+++ b/modular_ss220/modules/fixes_minor_1984/no_bitrun_huduse/human.dm
@@ -1,0 +1,9 @@
+/mob/living/carbon/human/canUseHUD()
+	. = ..()
+	if (!.)
+		return FALSE
+	var/area/cur_area = get_area(src)
+	if (!cur_area)
+		return .
+	. = !istype(cur_area, /area/virtual_domain)
+	return .

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9426,4 +9426,5 @@
 #include "modular_ss220\modules\extended_smes\smes.dm"
 #include "modular_ss220\modules\upstream-fixes\scarring_rejuve\human_helpers.dm"
 #include "modular_ss220\modules\crew_manifest_colored\crewmanifest.dm"
+#include "modular_ss220\modules\fixes_minor_1984\no_bitrun_huduse\human.dm"
 // END_INCLUDE


### PR DESCRIPTION
## Changelog

:cl:
fix: Huds no longer can change status from inside of bitrunning domains. Some other functional is limited as well from bitrunning.
/:cl:

****
- [x] Проверено на локалке
