### PR TITLE
del: unused client OOC verbs

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -473,72 +473,77 @@ ADMIN_VERB(reset_ooc_color, R_FUN, "Reset Player OOC Color", "Returns player OOC
 
 	prefs.savefile.export_json_to_client(usr, ckey)
 
-/client/verb/map_vote_tally_count()
-	set name = "Show Map Vote Tallies"
-	set desc = "View the current map vote tally counts."
-	set category = "Server"
-	to_chat(mob, SSmap_vote.tally_printout)
+// SS1984 REMOVAL START
+// /client/verb/map_vote_tally_count()
+// 	set name = "Show Map Vote Tallies"
+// 	set desc = "View the current map vote tally counts."
+// 	set category = "Server"
+// 	to_chat(mob, SSmap_vote.tally_printout)
+// SS1984 REMOVAL END
+
+// SS1984 REMOVAL START
+// /client/verb/linkforumaccount()
+// 	set category = "OOC"
+// 	set name = "Link Forum Account"
+// 	set desc = "Validates your byond account to your forum account. Required to post on the forums."
+
+// 	var/uri = CONFIG_GET(string/forum_link_uri)
+// 	if(!uri)
+// 		to_chat(src, span_warning("This feature is disabled."))
+// 		return
+
+// 	if (!SSdbcore.Connect())
+// 		to_chat(src, span_danger("No connection to the database."))
+// 		return
+
+// 	if  (is_guest_key(ckey))
+// 		to_chat(src, span_danger("Guests can not link accounts."))
+// 		return
+
+// 	var/token = generate_account_link_token()
+
+// 	var/datum/db_query/query_set_token = SSdbcore.NewQuery("INSERT INTO phpbb.tg_byond_oauth_tokens (`token`, `key`) VALUES (:token, :key)", list("token" = token, "key" = key))
+// 	if(!query_set_token.Execute())
+// 		to_chat(src, span_danger("Failed to insert account link token into database, please try again later."))
+// 		qdel(query_set_token)
+// 		return
+
+// 	qdel(query_set_token)
+
+// 	to_chat(src, "Now opening a window to login to your forum account, your account will automatically be linked the moment you log in. If this window doesn't load, Please go to <a href=\"[uri]?token=[token]\">[uri]?token=[token]</a> - This link will expire in 30 minutes.")
+// 	src << link("[uri]?token=[token]")
+// SS1984 REMOVAL END
+
+// SS1984 REMOVAL START
+// /client/proc/generate_account_link_token()
+// 	var/static/entropychain
+// 	if (!entropychain)
+// 		if (fexists("data/entropychain.txt"))
+// 			entropychain = file2text("entropychain.txt")
+// 		else
+// 			entropychain = "LOL THERE IS NO ENTROPY #HEATDEATH"
+// 	else if (prob(rand(1,15)))
+// 		text2file("data/entropychain.txt", entropychain)
+
+// 	var/datum/db_query/query_get_token = SSdbcore.NewQuery("SELECT [random_string()], [random_string()]", list(random_string_args(entropychain), random_string_args(entropychain)))
+
+// 	if(!query_get_token.Execute())
+// 		to_chat(src, span_danger("Failed to get random string token from database. (Error #1)"))
+// 		qdel(query_get_token)
+// 		return
+
+// 	if(!query_get_token.NextRow())
+// 		to_chat(src, span_danger("Could not locate your token in the database. (Error #2)"))
+// 		qdel(query_get_token)
+// 		return
+
+// 	entropychain = "[query_get_token.item[2]]"
+// 	return query_get_token.item[1]
 
 
-/client/verb/linkforumaccount()
-	set category = "OOC"
-	set name = "Link Forum Account"
-	set desc = "Validates your byond account to your forum account. Required to post on the forums."
+// /client/proc/random_string()
+// 	return "SHA2(CONCAT(RAND(),UUID(),?,RAND(),UUID()), 512)"
 
-	var/uri = CONFIG_GET(string/forum_link_uri)
-	if(!uri)
-		to_chat(src, span_warning("This feature is disabled."))
-		return
-
-	if (!SSdbcore.Connect())
-		to_chat(src, span_danger("No connection to the database."))
-		return
-
-	if  (is_guest_key(ckey))
-		to_chat(src, span_danger("Guests can not link accounts."))
-		return
-
-	var/token = generate_account_link_token()
-
-	var/datum/db_query/query_set_token = SSdbcore.NewQuery("INSERT INTO phpbb.tg_byond_oauth_tokens (`token`, `key`) VALUES (:token, :key)", list("token" = token, "key" = key))
-	if(!query_set_token.Execute())
-		to_chat(src, span_danger("Failed to insert account link token into database, please try again later."))
-		qdel(query_set_token)
-		return
-
-	qdel(query_set_token)
-
-	to_chat(src, "Now opening a window to login to your forum account, your account will automatically be linked the moment you log in. If this window doesn't load, Please go to <a href=\"[uri]?token=[token]\">[uri]?token=[token]</a> - This link will expire in 30 minutes.")
-	src << link("[uri]?token=[token]")
-
-/client/proc/generate_account_link_token()
-	var/static/entropychain
-	if (!entropychain)
-		if (fexists("data/entropychain.txt"))
-			entropychain = file2text("entropychain.txt")
-		else
-			entropychain = "LOL THERE IS NO ENTROPY #HEATDEATH"
-	else if (prob(rand(1,15)))
-		text2file("data/entropychain.txt", entropychain)
-
-	var/datum/db_query/query_get_token = SSdbcore.NewQuery("SELECT [random_string()], [random_string()]", list(random_string_args(entropychain), random_string_args(entropychain)))
-
-	if(!query_get_token.Execute())
-		to_chat(src, span_danger("Failed to get random string token from database. (Error #1)"))
-		qdel(query_get_token)
-		return
-
-	if(!query_get_token.NextRow())
-		to_chat(src, span_danger("Could not locate your token in the database. (Error #2)"))
-		qdel(query_get_token)
-		return
-
-	entropychain = "[query_get_token.item[2]]"
-	return query_get_token.item[1]
-
-
-/client/proc/random_string()
-	return "SHA2(CONCAT(RAND(),UUID(),?,RAND(),UUID()), 512)"
-
-/client/proc/random_string_args(entropychain)
-	return "[entropychain][GUID()][rand()*rand(999999)][world.time][GUID()][rand()*rand(999999)][world.timeofday][GUID()][rand()*rand(999999)][world.realtime][GUID()][rand()*rand(999999)][time2text(world.timeofday)][GUID()][rand()*rand(999999)][world.tick_usage][computer_id][address][ckey][key][GUID()][rand()*rand(999999)]"
+// /client/proc/random_string_args(entropychain)
+// 	return "[entropychain][GUID()][rand()*rand(999999)][world.time][GUID()][rand()*rand(999999)][world.timeofday][GUID()][rand()*rand(999999)][world.realtime][GUID()][rand()*rand(999999)][time2text(world.timeofday)][GUID()][rand()*rand(999999)][world.tick_usage][computer_id][address][ckey][key][GUID()][rand()*rand(999999)]"
+// SS1984 REMOVAL END


### PR DESCRIPTION
## Changelog

:cl:
del: Deleted unused client verbs, such as: "Link Forum Account", "Show Map Vote Tallies" (we don't use them at all)
/:cl:

****
- [x] Проверено на локалке
