### PR TITLE
qol: ion jetpack module autopin

### DIFF
--- a/modular_ss220/modules/qol_casual_1984/autopin_jetpack_module/_module.dm
+++ b/modular_ss220/modules/qol_casual_1984/autopin_jetpack_module/_module.dm
@@ -1,0 +1,2 @@
+/obj/item/mod/module
+	var/auto_pin = FALSE

--- a/modular_ss220/modules/qol_casual_1984/autopin_jetpack_module/mod_control.dm
+++ b/modular_ss220/modules/qol_casual_1984/autopin_jetpack_module/mod_control.dm
@@ -1,0 +1,17 @@
+/obj/item/mod/control/pre_equipped/install(obj/item/mod/module/new_module, mob/user)
+	. = ..()
+	if (!new_module in modules) // failed to add
+		return .
+	if (!new_module || !new_module.auto_pin || !user)
+		return .
+	if (!(new_module.type in default_pins))
+		default_pins[new_module.type] = list() // add to default pins. Note that it's type adding here, not wearer ref!
+	// ok now try to pin, if can do so
+	if (wearer != user || !wearer)
+		return . // not wearing, no need to pin right now
+	if(REF(wearer) in default_pins[new_module.type]) //if we already had pinned once to this user
+		return .
+	// looks like we can pin
+	default_pins[new_module.type] += REF(wearer)
+	new_module.pin(user)
+	return .

--- a/modular_ss220/modules/qol_casual_1984/autopin_jetpack_module/mod_control.dm
+++ b/modular_ss220/modules/qol_casual_1984/autopin_jetpack_module/mod_control.dm
@@ -1,6 +1,6 @@
 /obj/item/mod/control/pre_equipped/install(obj/item/mod/module/new_module, mob/user)
 	. = ..()
-	if (!new_module in modules) // failed to add
+	if (!(new_module in modules)) // failed to add
 		return .
 	if (!new_module || !new_module.auto_pin || !user)
 		return .

--- a/modular_ss220/modules/qol_casual_1984/autopin_jetpack_module/modules_general.dm
+++ b/modular_ss220/modules/qol_casual_1984/autopin_jetpack_module/modules_general.dm
@@ -1,0 +1,5 @@
+/obj/item/mod/module/jetpack
+	auto_pin = TRUE
+
+/obj/item/mod/module/jetpack/advanced
+	auto_pin = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9429,4 +9429,7 @@
 #include "modular_ss220\modules\fixes_minor_1984\no_bitrun_huduse\human.dm"
 #include "modular_ss220\modules\qol_casual_1984\engivend_jetpacks\modules_general.dm"
 #include "modular_ss220\modules\qol_casual_1984\engivend_jetpacks\engivend.dm"
+#include "modular_ss220\modules\qol_casual_1984\autopin_jetpack_module\modules_general.dm"
+#include "modular_ss220\modules\qol_casual_1984\autopin_jetpack_module\_module.dm"
+#include "modular_ss220\modules\qol_casual_1984\autopin_jetpack_module\mod_control.dm"
 // END_INCLUDE


### PR DESCRIPTION
## Changelog

:cl:
qol: Ion Jetpack module is now auto-pinned on insert to pre-equipped MODsuits (not for fully hand-crafted MODs)
/:cl:

****
- [x] Проверено на локалке
