### PR TITLE
add: healthanalyzer to autolathe

### DIFF
--- a/modular_ss220/modules/qol_casual_1984/healthanalyzer_autolathe/medical_designs.dm
+++ b/modular_ss220/modules/qol_casual_1984/healthanalyzer_autolathe/medical_designs.dm
@@ -1,0 +1,2 @@
+/datum/design/healthanalyzer
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE

--- a/modular_ss220/modules/qol_casual_1984/healthanalyzer_autolathe/medical_designs.dm
+++ b/modular_ss220/modules/qol_casual_1984/healthanalyzer_autolathe/medical_designs.dm
@@ -1,2 +1,6 @@
 /datum/design/healthanalyzer
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL,
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9432,4 +9432,5 @@
 #include "modular_ss220\modules\qol_casual_1984\autopin_jetpack_module\modules_general.dm"
 #include "modular_ss220\modules\qol_casual_1984\autopin_jetpack_module\_module.dm"
 #include "modular_ss220\modules\qol_casual_1984\autopin_jetpack_module\mod_control.dm"
+#include "modular_ss220\modules\qol_casual_1984\healthanalyzer_autolathe\medical_designs.dm"
 // END_INCLUDE


### PR DESCRIPTION
Теперь СБ сможет отслеживать повреждения для более точного применения 101/201/301/401 статей, антагам тоже проще получить анализатор

## Changelog

:cl:
add: Health analyzer (basic) is added to autolathe designs
/:cl:

****
- [x] Проверено на локалке
