### PR TITLE
map: Added 2 more atmos suit storage to recommended maps

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -14459,15 +14459,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/lab)
-"dzQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/massdriver_ordnance,
-/obj/machinery/atmos_shield_gen/active{
-	dir = 1
-	},
-/obj/machinery/atmos_shield_gen/active,
-/turf/open/floor/plating/airless,
-/area/station/science/ordnance/testlab)
 "dAl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -34759,6 +34750,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
 "iEg" = (
@@ -40622,6 +40614,7 @@
 /obj/effect/turf_decal/box/red/corners{
 	dir = 8
 	},
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/storage)
 "jYC" = (
@@ -56481,13 +56474,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
-"nZe" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/tile/red/fourcorners,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/medical/medsci)
 "nZf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -98033,14 +98019,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"ykj" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "ykl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -120157,7 +120135,7 @@ iBR
 dEL
 iBR
 gAw
-ykj
+dAl
 rsq
 qSL
 dPB
@@ -134589,7 +134567,7 @@ ndc
 sUH
 dcG
 qfi
-nZe
+brm
 brm
 qfi
 rxc

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -7037,6 +7037,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron/textured,
 /area/station/engineering/atmos)
 "bSH" = (
@@ -48809,6 +48810,7 @@
 /area/station/science/research)
 "nSc" = (
 /obj/effect/turf_decal/siding/yellow,
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nSk" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21719,17 +21719,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"hHk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Security E.V.A. Storage"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/security/brig)
 "hHt" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
 	dir = 4
@@ -28264,10 +28253,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/space_heater,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/storage/gas)
 "jMY" = (
@@ -28782,6 +28771,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/storage/gas)
 "jVb" = (
@@ -45649,6 +45639,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/storage/gas)
 "pQO" = (
@@ -66264,11 +66255,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/space_heater,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/storage/gas)
 "wNa" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -19217,8 +19217,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/obj/machinery/space_heater,
 /obj/machinery/light/directional/north,
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fKn" = (
@@ -31264,13 +31264,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "kce" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/effect/spawner/random{
-	name = "funny slipper :)";
-	loot = list(/obj/effect/decal/cleanable/blood/oil/slippery=10, /obj/effect/decal/cleanable/blood/oil=90)
-	},
-/turf/open/floor/tram/plate,
-/area/station/hallway/primary/tram/left)
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "kcm" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -44542,7 +44538,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/machinery/space_heater,
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oMc" = (
@@ -52731,6 +52727,7 @@
 /obj/machinery/camera/emp_proof/directional/north{
 	c_tag = "Engineering - Atmospherics North"
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rDt" = (
@@ -105656,7 +105653,7 @@ kpq
 rDj
 tTW
 vUk
-wQm
+kce
 skM
 bZW
 qkN


### PR DESCRIPTION
##  Скриншоты

### Delta

<img width="543" height="660" alt="image" src="https://github.com/user-attachments/assets/bb139cf0-9be4-4c44-8d9a-1b3a58a2c197" />

### Meta

<img width="735" height="826" alt="image" src="https://github.com/user-attachments/assets/77d688d7-bdde-4f5e-98ae-e47accdd883f" />

### Tram

<img width="747" height="649" alt="image" src="https://github.com/user-attachments/assets/cf8619f9-a0c6-4ed1-9c13-d10924557798" />

### Icebox

<img width="631" height="572" alt="image" src="https://github.com/user-attachments/assets/d6e4dca8-6662-49fa-bf3c-eaac048508f3" />

## Changelog

:cl:
map: Added 2 more atmos MODsuits storage units to all recommended maps (Delta, Meta, Tram, Icebox). Now it's 3 in total.
/:cl:

****
- [x] Проверено на локалке