### PR TITLE
map: replaced almost all empty defibs at maps/templates with loaded

### DIFF
--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
@@ -2454,7 +2454,7 @@
 /area/ruin/interdyne_planetary_base/cargo)
 "us" = (
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional{
+/obj/machinery/defibrillator_mount/loaded/directional{
 	pixel_y = 26
 	},
 /turf/open/floor/iron/dark/textured_large,

--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1984.dmm
@@ -2465,7 +2465,7 @@
 /area/ruin/interdyne_planetary_base/cargo)
 "us" = (
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional{
+/obj/machinery/defibrillator_mount/loaded/directional{
 	pixel_y = 26
 	},
 /turf/open/floor/iron/dark/textured_large,

--- a/_maps/RandomZLevels/TheBeach.dmm
+++ b/_maps/RandomZLevels/TheBeach.dmm
@@ -2005,7 +2005,7 @@
 /turf/open/floor/wood/large,
 /area/awaymission/beach)
 "zI" = (
-/obj/machinery/defibrillator_mount/directional/west,
+/obj/machinery/defibrillator_mount/loaded/directional/west,
 /obj/structure/bed/pod{
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
 	dir = 4;
@@ -2898,7 +2898,7 @@
 	dir = 4;
 	name = "medical bed"
 	},
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /obj/machinery/iv_drip{
 	pixel_y = 21;
 	pixel_x = -4

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -22794,7 +22794,7 @@
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
 	name = "medical bed"
 	},
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "gNK" = (
@@ -40541,7 +40541,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 4
 	},
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "lYe" = (
@@ -43031,7 +43031,7 @@
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
 	name = "medical bed"
 	},
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "mKF" = (
@@ -51891,7 +51891,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 4
 	},
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /obj/machinery/light/directional/east,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/textured_large,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -21701,7 +21701,7 @@
 	},
 /area/station/hallway/primary/central/aft)
 "fsB" = (
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/item/storage/box/gloves{
 	pixel_x = 3;
 	pixel_y = 3
@@ -40142,7 +40142,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jRJ" = (
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/item/radio/intercom/directional/west,
 /obj/item/emergency_bed{
 	pixel_y = 6
@@ -44331,7 +44331,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "kXa" = (
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/item/reagent_containers/cup/bottle/epinephrine,
 /obj/item/reagent_containers/cup/bottle/multiver{
 	pixel_x = 6
@@ -46075,7 +46075,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "ltz" = (
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/item/radio/intercom/directional/east,
 /obj/item/storage/box/bodybags{
 	pixel_x = 3;

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -36069,7 +36069,7 @@
 /turf/open/floor/iron/textured,
 /area/station/commons/storage/mining)
 "kmG" = (
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/effect/turf_decal/tile/blue/full,
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/stasis{
@@ -57980,7 +57980,7 @@
 /area/station/hallway/primary/central)
 "qsQ" = (
 /obj/machinery/stasis,
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
@@ -65326,7 +65326,7 @@
 	pixel_x = 6
 	},
 /obj/item/reagent_containers/syringe,
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -20252,7 +20252,7 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "hgu" = (
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/light/cold/directional/south,
 /obj/structure/bed/medical,
@@ -23591,7 +23591,7 @@
 /obj/machinery/stasis{
 	dir = 4
 	},
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/white,
@@ -53534,7 +53534,7 @@
 /area/station/cargo/storage)
 "sAv" = (
 /obj/machinery/stasis,
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/white,

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -6595,7 +6595,7 @@
 /obj/structure/bed/medical/anchored{
 	dir = 1
 	},
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bpn" = (
@@ -16125,7 +16125,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "dcr" = (
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "dcJ" = (
@@ -18445,7 +18445,7 @@
 /area/station/hallway/primary/upper)
 "dAK" = (
 /obj/machinery/iv_drip,
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/machinery/stasis{
 	dir = 4
 	},
@@ -33742,7 +33742,7 @@
 /area/station/maintenance/department/medical)
 "gwk" = (
 /obj/machinery/iv_drip,
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/machinery/stasis{
 	dir = 4
 	},
@@ -45986,7 +45986,7 @@
 /obj/structure/bed/medical/anchored{
 	dir = 1
 	},
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -72542,7 +72542,7 @@
 	},
 /area/station/hallway/primary/central)
 "nWC" = (
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/machinery/light/directional/south,
 /obj/structure/table/optable,
 /turf/open/floor/iron,
@@ -113396,7 +113396,7 @@
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "vGH" = (
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/machinery/light/directional/north,
 /obj/structure/table/optable,
 /turf/open/floor/iron,

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -47137,7 +47137,7 @@
 	dir = 8
 	},
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /obj/item/restraints/handcuffs,
 /obj/item/clothing/mask/muzzle,
 /turf/open/floor/iron/dark/smooth_half{
@@ -57797,7 +57797,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/medical/surgery/theatre)
@@ -60129,7 +60129,7 @@
 	c_tag = "Medbay - Primary Treatment Centre Starboard";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rwZ" = (
@@ -61377,7 +61377,7 @@
 /turf/open/misc/asteroid/moon/airless,
 /area/station/asteroid)
 "rRh" = (
-/obj/machinery/defibrillator_mount/directional/west,
+/obj/machinery/defibrillator_mount/loaded/directional/west,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
@@ -78021,7 +78021,7 @@
 "wAH" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/bot_white,
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/effect/turf_decal/tile/blue/full,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1

--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -17421,7 +17421,7 @@
 	pixel_y = -7
 	},
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional/east{
+/obj/machinery/defibrillator_mount/loaded/directional/east{
 	pixel_y = 4
 	},
 /obj/structure/cable,
@@ -27511,7 +27511,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "hRl" = (
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -44115,7 +44115,7 @@
 	name = "medical bed"
 	},
 /obj/machinery/iv_drip,
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
@@ -44136,7 +44136,7 @@
 	dir = 1
 	},
 /obj/machinery/stasis,
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -69531,7 +69531,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/obj/machinery/defibrillator_mount/directional/west,
+/obj/machinery/defibrillator_mount/loaded/directional/west,
 /obj/machinery/stasis{
 	dir = 1
 	},
@@ -72141,7 +72141,7 @@
 	name = "medical bed"
 	},
 /obj/machinery/iv_drip,
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
@@ -81342,7 +81342,7 @@
 	pixel_y = -7
 	},
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional/east{
+/obj/machinery/defibrillator_mount/loaded/directional/east{
 	pixel_y = 4
 	},
 /obj/structure/cable,

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -7438,7 +7438,7 @@
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/virology)
 "bXb" = (
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/effect/spawner/surgery_tray/full,
 /obj/effect/turf_decal/tile/blue/half,
 /obj/structure/table/reinforced,
@@ -37941,7 +37941,7 @@
 /area/station/hallway/primary/aftporthall)
 "kcR" = (
 /obj/machinery/stasis,
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
@@ -39388,7 +39388,7 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "kvj" = (
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/effect/spawner/surgery_tray/full,
 /obj/effect/turf_decal/tile/blue/half,
 /obj/structure/table/reinforced,

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -1724,7 +1724,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/fore)
 "ayV" = (
-/obj/machinery/defibrillator_mount/directional/west,
+/obj/machinery/defibrillator_mount/loaded/directional/west,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/stasis{
 	dir = 4
@@ -38117,7 +38117,7 @@
 /area/station/medical/medbay/lobby)
 "kMs" = (
 /obj/machinery/stasis,
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/effect/turf_decal/box/blue,
 /turf/open/floor/iron/freezer,
@@ -44128,7 +44128,7 @@
 	pixel_y = -7
 	},
 /obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/defibrillator_mount/directional/east{
+/obj/machinery/defibrillator_mount/loaded/directional/east{
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/box/red,
@@ -65809,7 +65809,7 @@
 	name = "Privacy Shutters Control";
 	pixel_y = -7
 	},
-/obj/machinery/defibrillator_mount/directional/east{
+/obj/machinery/defibrillator_mount/loaded/directional/east{
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/box/red,

--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -7094,7 +7094,7 @@
 "gki" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/stasis,
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /turf/open/floor/iron/freezer,
 /area/centcom/interlink)
 "gko" = (
@@ -7767,7 +7767,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/machinery/defibrillator_mount/directional/west,
+/obj/machinery/defibrillator_mount/loaded/directional/west,
 /obj/machinery/computer/operating{
 	dir = 4
 	},

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -22194,7 +22194,7 @@
 /obj/structure/bed/medical{
 	dir = 4
 	},
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -27332,7 +27332,7 @@
 /obj/machinery/stasis{
 	dir = 8
 	},
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
@@ -29199,7 +29199,7 @@
 /obj/structure/bed/medical{
 	dir = 8
 	},
-/obj/machinery/defibrillator_mount/directional/west,
+/obj/machinery/defibrillator_mount/loaded/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -53219,7 +53219,7 @@
 /obj/machinery/stasis{
 	dir = 4
 	},
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -4052,7 +4052,7 @@
 /obj/machinery/stasis{
 	dir = 4
 	},
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bvl" = (
@@ -33006,7 +33006,7 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "lxP" = (
-/obj/machinery/defibrillator_mount/directional/west,
+/obj/machinery/defibrillator_mount/loaded/directional/west,
 /obj/machinery/stasis{
 	dir = 4
 	},
@@ -46868,7 +46868,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "qog" = (

--- a/_maps/nova/lazy_templates/midround_traitor.dmm
+++ b/_maps/nova/lazy_templates/midround_traitor.dmm
@@ -2336,7 +2336,7 @@
 	pixel_x = -3;
 	pixel_y = 9
 	},
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/misc/operative_barracks/surgery)
 "Er" = (

--- a/_maps/shuttles/emergency_fame.dmm
+++ b/_maps/shuttles/emergency_fame.dmm
@@ -756,7 +756,7 @@
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
 /obj/machinery/light/directional/west,
-/obj/machinery/defibrillator_mount/directional/west,
+/obj/machinery/defibrillator_mount/loaded/directional/west,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "HZ" = (

--- a/_maps/shuttles/emergency_nebula.dmm
+++ b/_maps/shuttles/emergency_nebula.dmm
@@ -2449,7 +2449,7 @@
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/directional/east,
 /obj/effect/spawner/surgery_tray/full,
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_northstar.dmm
+++ b/_maps/shuttles/emergency_northstar.dmm
@@ -118,7 +118,7 @@
 /area/shuttle/escape)
 "nt" = (
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
 	},

--- a/_maps/shuttles/nova/pirate_nri_raider.dmm
+++ b/_maps/shuttles/nova/pirate_nri_raider.dmm
@@ -332,7 +332,7 @@
 /area/shuttle/pirate/nri)
 "mJ" = (
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate/nri)
 "nX" = (

--- a/_maps/shuttles/nova/slaver_syndie.dmm
+++ b/_maps/shuttles/nova/slaver_syndie.dmm
@@ -816,7 +816,7 @@
 /area/shuttle/syndicate/slaver)
 "Lf" = (
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /obj/effect/turf_decal/trimline/dark_blue/warning{
 	dir = 1

--- a/_maps/shuttles/nova/whiteship_blueshift.dmm
+++ b/_maps/shuttles/nova/whiteship_blueshift.dmm
@@ -4829,7 +4829,7 @@
 "UK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/structure/alien/weeds,
 /obj/effect/mob_spawn/corpse/human/doctor,
 /turf/open/floor/iron/white,

--- a/_maps/shuttles/whiteship_birdshot.dmm
+++ b/_maps/shuttles/whiteship_birdshot.dmm
@@ -709,7 +709,7 @@
 /area/shuttle/abandoned/crew)
 "xT" = (
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/shuttle/abandoned/medbay)

--- a/_maps/templates/lazy_templates/ninja_den.dmm
+++ b/_maps/templates/lazy_templates/ninja_den.dmm
@@ -1804,7 +1804,7 @@
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
 "Qu" = (
-/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
 /obj/machinery/stasis,
 /turf/open/floor/iron/sepia,
 /area/centcom/central_command_areas/holding)
@@ -1997,7 +1997,7 @@
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
 "Vi" = (
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /obj/machinery/stasis,
 /turf/open/floor/iron/sepia,
 /area/centcom/central_command_areas/holding)

--- a/_maps/virtual_domains/island_brawl.dmm
+++ b/_maps/virtual_domains/island_brawl.dmm
@@ -105,7 +105,7 @@
 /turf/open/water/beach,
 /area/virtual_domain/fullbright)
 "bx" = (
-/obj/machinery/defibrillator_mount/directional/west,
+/obj/machinery/defibrillator_mount/loaded/directional/west,
 /obj/structure/bed/pod{
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
 	dir = 4;
@@ -2692,7 +2692,7 @@
 	dir = 4;
 	name = "medical bed"
 	},
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
 /obj/machinery/iv_drip{
 	pixel_y = 21;
 	pixel_x = -4

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -20,6 +20,7 @@
 	var/wallframe_type = /obj/item/wallframe/defib_mount
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/defibrillator_mount, 28)
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/defibrillator_mount/loaded, 28) // SS1984 ADDITION
 
 /obj/machinery/defibrillator_mount/loaded/Initialize(mapload) //loaded subtype for mapping use
 	. = ..()


### PR DESCRIPTION
Вместо пустых дефибов будут сразу заряженные в меде и не только (на шаттлах, темплейт-зонах и т.д.)

## Changelog

:cl:
map: Replaced almost all empty defibs on all maps/templates with initially loaded defibs
/:cl:

****
- [x] Проверено на локалке
