### PR TITLE
fix: Loaded defibs at maps now properly shows attached defib overlay

### DIFF
--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -26,6 +26,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/defibrillator_mount/loaded, 28) // SS
 	. = ..()
 	defib = new/obj/item/defibrillator/loaded(src)
 	find_and_hang_on_wall()
+	update_icon() // SS1984 ADDITION, could be modular but i believe it's TG bugfix for defib overlays
 
 /obj/machinery/defibrillator_mount/Destroy()
 	QDEL_NULL(defib)

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -26,7 +26,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/defibrillator_mount/loaded, 28) // SS
 	. = ..()
 	defib = new/obj/item/defibrillator/loaded(src)
 	find_and_hang_on_wall()
-	update_icon() // SS1984 ADDITION, could be modular but i believe it's TG bugfix for defib overlays
+	update_appearance() // SS1984 ADDITION, could be modular but i believe it's TG bugfix for defib overlays
 
 /obj/machinery/defibrillator_mount/Destroy()
 	QDEL_NULL(defib)


### PR DESCRIPTION
Визуально когда берешь дефиб со стены, у него не исчезает оверлей а остается. Возможно это фича, если что пофикшу отдельно

## Changelog

:cl:
fix: Loaded defibs at maps now properly shows attached defib overlay
/:cl:

****
- [x] Проверено на локалке
