### PR TITLE
qol: Removed nifsoft default examine text

### DIFF
--- a/modular_nova/modules/modular_implants/code/nifs_tgui.dm
+++ b/modular_nova/modules/modular_implants/code/nifs_tgui.dm
@@ -102,7 +102,7 @@
 				return FALSE
 
 			if(!text_to_use || length(text_to_use) <= 6)
-				examine_datum.nif_examine_text = "There's a certain spark to their eyes."
+				examine_datum.nif_examine_text = "" // SS1984 EDIT, original: examine_datum.nif_examine_text = "There's a certain spark to their eyes."
 				return FALSE
 
 			examine_datum.nif_examine_text = text_to_use

--- a/modular_ss220/modules/disable_upstream_stuff/no_default_nif_examine/nifs.dm
+++ b/modular_ss220/modules/disable_upstream_stuff/no_default_nif_examine/nifs.dm
@@ -1,0 +1,7 @@
+/datum/component/nif_examine
+	nif_examine_text = ""
+
+/datum/component/nif_examine/add_examine(mob/nif_user, mob/looker, list/examine_texts)
+	if (!nif_examine_text || length(nif_examine_text) < 1)
+		return
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9422,6 +9422,7 @@
 #include "modular_ss220\modules\changelog_highlight\changelog.dm"
 #include "modular_ss220\modules\forbid_imprint_trim\job.dm"
 #include "modular_ss220\modules\disable_upstream_stuff\safety_additions.dm"
+#include "modular_ss220\modules\disable_upstream_stuff\no_default_nif_examine\nifs.dm"
 #include "modular_ss220\modules\extended_smes\machine_circuitboards.dm"
 #include "modular_ss220\modules\extended_smes\smes.dm"
 #include "modular_ss220\modules\upstream-fixes\scarring_rejuve\human_helpers.dm"


### PR DESCRIPTION
## Changelog

:cl:
qol: Removed NIFsoft default examine text ("There's a certain spark to their eyes."). You need to set it manually if you want it to appear (more than 6 characters)
/:cl:

****
- [x] Проверено на локалке