### PR TITLE
code: Better dynamic checking players

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -774,7 +774,7 @@ SUBSYSTEM_DEF(dynamic)
 				if(high_impact_ruleset_executed)
 					return FALSE
 
-	var/population = GLOB.alive_player_list.len
+	var/population = get_population_for_dynamic_rolling() // SS1984 EDIT, original: var/population = GLOB.alive_player_list.len
 	if((new_rule.acceptable(population, threat_level) && (ignore_cost || new_rule.cost <= mid_round_budget)) || forced)
 		new_rule.trim_candidates()
 		new_rule.load_templates()
@@ -847,12 +847,13 @@ SUBSYSTEM_DEF(dynamic)
 	var/was_forced = late_forced_injection
 	late_forced_injection = FALSE
 	var/list/possible_latejoin_rules = list()
+	var/pop_count_filtered = get_population_for_dynamic_rolling() // SS1984 ADDITION
 	for (var/datum/dynamic_ruleset/latejoin/rule in latejoin_rules)
 		if(!rule.weight)
 			continue
 		if(mid_round_budget < rule.cost)
 			continue
-		if(!rule.acceptable(GLOB.alive_player_list.len, threat_level))
+		if(!rule.acceptable(pop_count_filtered, threat_level)) // SS1984 EDIT, original: if(!rule.acceptable(GLOB.alive_player_list.len, threat_level))
 			continue
 		possible_latejoin_rules[rule] = rule.get_weight()
 

--- a/code/controllers/subsystem/dynamic/dynamic_logging.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_logging.dm
@@ -88,7 +88,7 @@
 
 	new_snapshot.remaining_threat = mid_round_budget
 	new_snapshot.time = world.time
-	new_snapshot.alive_players = GLOB.alive_player_list.len
+	new_snapshot.alive_players = SSdynamic ? SSdynamic.get_population_for_dynamic_rolling() : GLOB.alive_player_list.len
 	new_snapshot.dead_players = GLOB.dead_player_list.len
 	new_snapshot.observers = GLOB.current_observers_list.len
 	new_snapshot.total_players = new_snapshot.alive_players + new_snapshot.dead_players + new_snapshot.observers

--- a/code/controllers/subsystem/dynamic/dynamic_midround_rolling.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_midround_rolling.dm
@@ -38,16 +38,16 @@
 
 	var/list/drafted_heavies = list()
 	var/list/drafted_lights = list()
-
+	var/pop_count_filtered = get_population_for_dynamic_rolling() // SS1984 ADDITION
 	for (var/datum/dynamic_ruleset/midround/ruleset in midround_rules)
 		if (ruleset.weight == 0)
 			log_dynamic("FAIL: [ruleset] has a weight of 0")
 			continue
 
-		if (!ruleset.acceptable(GLOB.alive_player_list.len, threat_level))
+		if (!ruleset.acceptable(pop_count_filtered, threat_level)) // SS1984 EDIT, original: if (!ruleset.acceptable(GLOB.alive_player_list.len, threat_level))
 			var/ruleset_forced = GLOB.dynamic_forced_rulesets[type] || RULESET_NOT_FORCED
 			if (ruleset_forced == RULESET_NOT_FORCED)
-				log_dynamic("FAIL: [ruleset] is not acceptable with the current parameters. Alive players: [GLOB.alive_player_list.len], threat level: [threat_level]")
+				log_dynamic("FAIL: [ruleset] is not acceptable with the current parameters. Alive players: [pop_count_filtered], threat level: [threat_level]") // SS1984 EDIT, original: log_dynamic("FAIL: [ruleset] is not acceptable with the current parameters. Alive players: [GLOB.alive_player_list.len], threat level: [threat_level]")
 			else
 				log_dynamic("FAIL: [ruleset] was disabled.")
 			continue
@@ -100,7 +100,7 @@
 	if (GLOB.current_living_antags.len == 0)
 		chance_modifier += 0.5
 
-	if (GLOB.dead_player_list.len > GLOB.alive_player_list.len)
+	if (GLOB.dead_player_list.len > get_population_for_dynamic_rolling()) // SS1984 EDIT, original: if (GLOB.dead_player_list.len > GLOB.alive_player_list.len)
 		chance_modifier -= 0.3
 
 	var/heavy_coefficient = CLAMP01((next_midround_roll - midround_light_upper_bound) / (midround_heavy_lower_bound - midround_light_upper_bound))

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_latejoin.dm
@@ -35,6 +35,10 @@
 		for (var/mob/M in GLOB.alive_player_list)
 			if (M.stat == DEAD)
 				continue // Dead players cannot count as opponents
+			// SS1984 ADDITION START
+			if (!SSdynamic.is_mob_considered_as_valid(M))
+				continue
+			// SS1984 ADDITION END
 			if (M.mind && (M.mind.assigned_role.title in enemy_roles) && (!(M in candidates) || (M.mind.assigned_role.title in restricted_roles)))
 				job_check++ // Checking for "enemies" (such as sec officers). To be counters, they must either not be candidates to that rule, or have a job that restricts them from it
 
@@ -137,6 +141,10 @@
 		return FALSE
 	var/head_check = 0
 	for(var/mob/player in GLOB.alive_player_list)
+		// SS1984 ADDITION START
+		if (!SSdynamic.is_mob_considered_as_valid(player))
+			continue
+		// SS1984 ADDITION END
 		if (player.mind.assigned_role.job_flags & JOB_HEAD_OF_STAFF)
 			head_check++
 	return (head_check >= required_heads_of_staff)

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -114,6 +114,10 @@
 		for (var/mob/M in GLOB.alive_player_list)
 			if (M.stat == DEAD || !M.client)
 				continue // Dead/disconnected players cannot count as opponents
+			// SS1984 ADDITION START
+			if (!SSdynamic.is_mob_considered_as_valid(M))
+				continue
+			// SS1984 ADDITION END
 			if (M.mind && (M.mind.assigned_role.title in enemy_roles) && (!(M in candidates) || (M.mind.assigned_role.title in restricted_roles)))
 				job_check++ // Checking for "enemies" (such as sec officers). To be counters, they must either not be candidates to that rule, or have a job that restricts them from it
 

--- a/code/controllers/subsystem/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_unfavorable_situation.dm
@@ -29,6 +29,7 @@
 		return list()
 
 	var/list/possible_heavies = list()
+	var/pop_count_filtered = get_population_for_dynamic_rolling() // SS1984 ADDITION
 	for (var/datum/dynamic_ruleset/midround/ruleset as anything in midround_rules)
 		if (ruleset.midround_ruleset_style != MIDROUND_RULESET_STYLE_HEAVY)
 			continue
@@ -39,7 +40,7 @@
 		if (ruleset.cost > max_threat_level)
 			continue
 
-		if (!ruleset.acceptable(GLOB.alive_player_list.len, threat_level))
+		if (!ruleset.acceptable(pop_count_filtered, threat_level)) // SS1984 EDIT, original: if (!ruleset.acceptable(GLOB.alive_player_list.len, threat_level))
 			continue
 
 		if (ruleset.minimum_round_time > world.time - SSticker.round_start_time)

--- a/code/controllers/subsystem/dynamic/ruleset_picking.dm
+++ b/code/controllers/subsystem/dynamic/ruleset_picking.dm
@@ -106,7 +106,7 @@
 /datum/controller/subsystem/dynamic/proc/execute_midround_latejoin_rule(sent_rule)
 	var/datum/dynamic_ruleset/rule = sent_rule
 	spend_midround_budget(rule.cost, threat_log, "[gameTimestamp()]: [rule.ruletype] [rule.name]")
-	rule.pre_execute(GLOB.alive_player_list.len)
+	rule.pre_execute(get_population_for_dynamic_rolling()) // SS1984 EDIT, original: rule.pre_execute(GLOB.alive_player_list.len)
 	if (rule.execute())
 		log_dynamic("Injected a [rule.ruletype] ruleset [rule.name].")
 		if(rule.flags & HIGH_IMPACT_RULESET)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -981,8 +981,9 @@ GLOBAL_VAR_INIT(cops_arrived, FALSE)
 			SSdynamic.unfavorable_situation()
 
 		if(HACK_SLEEPER) // Trigger one or multiple sleeper agents with the crew (or for latejoining crew)
+			var/pop_filtered = SSdynamic ? SSdynamic.get_population_for_dynamic_rolling() : GLOB.alive_player_list.len // SS1984 ADDITION
 			var/datum/dynamic_ruleset/midround/sleeper_agent_type = /datum/dynamic_ruleset/midround/from_living/autotraitor
-			var/max_number_of_sleepers = clamp(round(length(GLOB.alive_player_list) / 20), 1, 3)
+			var/max_number_of_sleepers = clamp(round(pop_filtered / 20), 1, 3) // SS1984 EDIT, original: var/max_number_of_sleepers = clamp(round(length(GLOB.alive_player_list) / 20), 1, 3)
 			var/num_agents_created = 0
 			for(var/num_agents in 1 to rand(1, max_number_of_sleepers))
 				if(!SSdynamic.picking_specific_rule(sleeper_agent_type, forced = TRUE, ignore_cost = TRUE))

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -153,7 +153,7 @@ ADMIN_VERB(spawn_cargo, R_SPAWN, "Spawn Cargo", "Spawn a cargo crate.", ADMIN_CA
 		browser.open()
 		return
 
-	var/pop_count = length(GLOB.alive_player_list)
+	var/pop_count = SSdynamic.get_population_for_dynamic_rolling() // SS1984 EDIT, original: var/pop_count = length(GLOB.alive_player_list)
 	var/threat_level = SSdynamic.threat_level
 	dat += dynamic_ruleset_category_during_round_display("Latejoin", SSdynamic.latejoin_rules, pop_count, threat_level)
 	dat += dynamic_ruleset_category_during_round_display("Midround", SSdynamic.midround_rules, pop_count, threat_level)

--- a/modular_ss220/modules/dynamic_tweaks/dynamic_tweaks.dm
+++ b/modular_ss220/modules/dynamic_tweaks/dynamic_tweaks.dm
@@ -2,3 +2,28 @@
 	pop_per_requirement = pop_per_requirement > 0 ? pop_per_requirement : SSdynamic.pop_per_requirement
 	indice_pop = min(requirements.len,round(population/pop_per_requirement)+1)
 	return requirements[indice_pop]
+
+/datum/controller/subsystem/dynamic/proc/get_population_for_dynamic_rolling()
+	var/list/pop_unfiltered = GLOB.alive_player_list
+	if (!pop_unfiltered || length(pop_unfiltered) < 1)
+		return 0
+	var/pop_filtered_amount = 0
+	for(var/mob/living/living_mob in GLOB.alive_player_list)
+		if (is_mob_considered_as_valid(living_mob))
+			pop_filtered_amount++
+	return pop_filtered_amount
+
+/datum/controller/subsystem/dynamic/proc/is_mob_considered_as_valid(var/mob/mob_to_check)
+	var/mob/living/living_mob = mob_to_check
+	if (!living_mob || !living_mob.ckey || !GET_CLIENT(living_mob) || living_mob.ssd_indicator)
+		return FALSE
+	if (issilicon(living_mob))
+		return TRUE
+	var/mob/living/carbon/human/human_mob = living_mob
+	if (!human_mob || !human_mob.mind)
+		return FALSE
+	// No not-crew (ghost roles) or unassigned (at mind, not at card) roles
+	if (!human_mob.mind.assigned_role || !(human_mob.mind.assigned_role.job_flags & JOB_CREW_MEMBER))
+		return FALSE
+	// ok looks like valid player
+	return TRUE


### PR DESCRIPTION
## Changelog

:cl:
balance: Dynamic no longer counts non-station roles as "Alive" for rulesets population
fix: Dynamic rolling no longer counts SSD/disconnected players as "Alive"
code: Example how Dynamic count alive players now: 1 secoff, 1 disconnected crew, 1 SSD crew, 2 normal crew, 1 dead crew, and 1 non-station role (tarkon) = 3 alive players, antags normally start from 5 population (including 1 security/captain). The same principes applying to "enemies" selection, such when calculating amount of alive security/heads (for revs)
admin: Alive Players in dynamic panel now shows how much it count as "Alive" for rolling (no ghost roles... etc.). This might differ from other admin panels (it's should be that way)
/:cl:

****
- [x] Проверено на локалке