### PR TITLE
add: engineering skillchip to atmostech

### DIFF
--- a/modular_ss220/modules/qol_casual_1984/atmos_engi_skillchip/atmospheric_technician.dm
+++ b/modular_ss220/modules/qol_casual_1984/atmos_engi_skillchip/atmospheric_technician.dm
@@ -1,0 +1,2 @@
+/datum/outfit/job/atmos
+	skillchips = list(/obj/item/skillchip/job/engineer)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9439,4 +9439,5 @@
 #include "modular_ss220\modules\qol_casual_1984\autopin_jetpack_module\mod_control.dm"
 #include "modular_ss220\modules\qol_casual_1984\healthanalyzer_autolathe\medical_designs.dm"
 #include "modular_ss220\modules\qol_casual_1984\nanodrug_pills\medical.dm"
+#include "modular_ss220\modules\qol_casual_1984\atmos_engi_skillchip\atmospheric_technician.dm"
 // END_INCLUDE


### PR DESCRIPTION
## Changelog

:cl:
add: Atmos techs now start with engineering skillchip
/:cl:

****
- [x] Проверено на локалке
