### PR TITLE
fix: adminwho says info about no admins when there's admins

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -97,13 +97,12 @@
 /// Proc that generates the applicable string to dispatch to the client for adminwho.
 /client/proc/generate_adminwho_string()
 	var/list/list_of_admins = get_list_of_admins()
-	if(isnull(list_of_admins))
+	if(isnull(list_of_admins) || list_of_admins.len < 1)
 		return NO_ADMINS_ONLINE_MESSAGE
 
 	var/list/message_strings = list()
 	if(isnull(holder))
 		message_strings += get_general_adminwho_information(list_of_admins)
-		message_strings += NO_ADMINS_ONLINE_MESSAGE
 	else
 		message_strings += get_sensitive_adminwho_information(list_of_admins)
 


### PR DESCRIPTION
## Changelog

:cl:
fix: Adminwho for non-admins players no longer shows no-admins info, when there are admins
/:cl:

****
- [x] Проверено на локалке
