### PR TITLE
fix: toy turret kit no sprite at request console

### DIFF
--- a/modular_nova/modules/magfed_turret/code/turrets/cargo.dm
+++ b/modular_nova/modules/magfed_turret/code/turrets/cargo.dm
@@ -6,7 +6,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	flags_1 = IS_PLAYER_COLORABLE_1
 	w_class = WEIGHT_CLASS_NORMAL
-	icon = 'icons/map_icons/items/_item.dmi' // SS1984 EDIT, original: icons\map_icons\items\_item.dmi
+	icon = 'icons/map_icons/items/_item.dmi' // SS1984 EDIT, original: icons/map_icons/objects.dmi
 	icon_state = "/obj/item/storage/toolbox/emergency/turret/mag_fed/toy"
 	post_init_icon_state = "toy_toolbox"
 	greyscale_config = /datum/greyscale_config/turret/toolbox

--- a/modular_nova/modules/magfed_turret/code/turrets/cargo.dm
+++ b/modular_nova/modules/magfed_turret/code/turrets/cargo.dm
@@ -6,7 +6,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	flags_1 = IS_PLAYER_COLORABLE_1
 	w_class = WEIGHT_CLASS_NORMAL
-	icon = 'icons/map_icons/objects.dmi'
+	icon = 'icons/map_icons/items/_item.dmi' // SS1984 EDIT, original: icons\map_icons\items\_item.dmi
 	icon_state = "/obj/item/storage/toolbox/emergency/turret/mag_fed/toy"
 	post_init_icon_state = "toy_toolbox"
 	greyscale_config = /datum/greyscale_config/turret/toolbox


### PR DESCRIPTION
Модульно делать подобный фикс смысла нет, если апстрим потом перезапишет, так даже лучше

## Changelog

:cl:
fix: Added sprite to toy turret kit for request console (instead of ERROR)
/:cl:

****
- [x] Проверено на локалке