### PR TITLE
fix: no double equip ghost role spawners

### DIFF
--- a/modular_nova/master_files/code/modules/mob_spawn/mob_spawn.dm
+++ b/modular_nova/master_files/code/modules/mob_spawn/mob_spawn.dm
@@ -26,7 +26,7 @@
 				if(appearance_choice == "Yes")
 					load_prefs = TRUE
 
-	var/mob/living/spawned_mob = ..(mob_possessor, newname, load_prefs)
+	var/mob/living/spawned_mob = ..(mob_possessor, newname, "NOEQUIP")
 
 	var/mob/living/carbon/human/spawned_human
 	if (istype(spawned_mob, /mob/living/carbon/human))
@@ -35,7 +35,8 @@
 		if(!load_prefs)
 			var/datum/language_holder/holder = spawned_human.get_language_holder()
 			holder.get_selected_language() //we need this here so a language starts off selected
-
+			equip(spawned_mob) // SS1984 ADDITION
+			after_create_nova(spawned_human) // SS1984 ADDITION
 			return spawned_human
 
 		spawned_human?.client?.prefs?.safe_transfer_prefs_to(spawned_human)
@@ -53,7 +54,7 @@
 		spawned_human?.equip_outfit_and_loadout(outfit, spawned_mob.client.prefs)
 	else if (!isnull(spawned_human))
 		equip(spawned_human)
-
+	after_create_nova(spawned_human) // SS1984 ADDITION
 	return spawned_mob
 
 /// This edit would cause somewhat ugly diffs, so I'm just replacing it.
@@ -62,7 +63,8 @@
 	var/mob/living/spawned_mob = new mob_type(get_turf(src)) //living mobs only
 	name_mob(spawned_mob, newname)
 	special(spawned_mob, mob_possessor)
-	equip(spawned_mob)
+	if (use_loadout != "NOEQUIP") // SS1984 ADDITION
+		equip(spawned_mob)
 	return spawned_mob
 
 // Anything that can potentially be overwritten by transferring prefs must go in this proc

--- a/modular_nova/modules/cryosleep/code/cryopod.dm
+++ b/modular_nova/modules/cryosleep/code/cryopod.dm
@@ -595,8 +595,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/cryopod/prison, 18)
 	/// For figuring out where the local cryopod computer is. Must be set for cryo computer announcements.
 	var/area/computer_area
 
-/obj/effect/mob_spawn/ghost_role/create(mob/mob_possessor, newname, use_loadout = FALSE)
-	var/mob/living/spawned_mob = ..()
+/obj/effect/mob_spawn/ghost_role/proc/after_create_nova(mob/living/spawned_mob) // SS1984 EDIT, original: /obj/effect/mob_spawn/ghost_role/create(mob/mob_possessor, newname, use_loadout = FALSE)
 	var/obj/machinery/computer/cryopod/control_computer = find_control_computer()
 
 	var/alt_name = get_spawner_outfit_name()


### PR DESCRIPTION
## Changelog

:cl:
fix: Fixed double-equip outfit items for ghost role spawners
/:cl:

****
- [x] Проверено на локалке
