### PR TITLE
fix: cargo ui plasmacost for express & pda

### DIFF
--- a/modular_ss220/modules/plasma_inflation/budgetordering.dm
+++ b/modular_ss220/modules/plasma_inflation/budgetordering.dm
@@ -1,0 +1,17 @@
+/datum/computer_file/program/budgetorders/ui_data(mob/user)
+	. = ..()
+	if (!.)
+		return list()
+	var/list/data = .
+	if (!data)
+		return .
+	var/current_plasma_cost
+	if (SSplasma_inflation)
+		var/datum/plasma_inflation_market/market = SSplasma_inflation.get_market(EXPORT_MARKET_STATION)
+		current_plasma_cost = market.current_price
+		if (!isnum(current_plasma_cost))
+			current_plasma_cost = PLASMA_DEFAULT_COST_CARGO
+	else
+		current_plasma_cost = PLASMA_DEFAULT_COST_CARGO
+	data["current_plasma_cost"] = current_plasma_cost
+	return data

--- a/modular_ss220/modules/plasma_inflation/orderconsole.dm
+++ b/modular_ss220/modules/plasma_inflation/orderconsole.dm
@@ -14,3 +14,22 @@
 	else
 		current_plasma_cost = PLASMA_DEFAULT_COST_CARGO
 	data["current_plasma_cost"] = current_plasma_cost
+	return data
+
+/obj/machinery/computer/cargo/express/ui_data(mob/user)
+	. = ..()
+	if (!.)
+		return list()
+	var/list/data = .
+	if (!data)
+		return .
+	var/current_plasma_cost
+	if (SSplasma_inflation)
+		var/datum/plasma_inflation_market/market = SSplasma_inflation.get_market(EXPORT_MARKET_STATION)
+		current_plasma_cost = market.current_price
+		if (!isnum(current_plasma_cost))
+			current_plasma_cost = PLASMA_DEFAULT_COST_CARGO
+	else
+		current_plasma_cost = PLASMA_DEFAULT_COST_CARGO
+	data["current_plasma_cost"] = current_plasma_cost
+	return data

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9416,6 +9416,7 @@
 #include "modular_ss220\modules\plasma_inflation\plasma_inflation.dm"
 #include "modular_ss220\modules\plasma_inflation\exports.dm"
 #include "modular_ss220\modules\plasma_inflation\orderconsole.dm"
+#include "modular_ss220\modules\plasma_inflation\budgetordering.dm"
 #include "modular_ss220\modules\plasma_inflation\pirate_pad_equipment.dm"
 #include "modular_ss220\modules\plasma_inflation\syndiepad.dm"
 #include "modular_ss220\modules\localization_modular\ert.dm"

--- a/tgui/packages/tgui/interfaces/CargoExpress.tsx
+++ b/tgui/packages/tgui/interfaces/CargoExpress.tsx
@@ -26,6 +26,7 @@ type Data = {
   canBeacon: BooleanLike;
   printMsg: string;
   message: string;
+  current_plasma_cost: number | string; // SS1984 ADDITION
 };
 
 export function CargoExpress(props) {
@@ -70,6 +71,7 @@ function CargoExpressContent(props) {
     beaconName,
     canBuyBeacon,
     printMsg,
+    current_plasma_cost, // SS1984 ADDITION
   } = data;
 
   return (
@@ -79,8 +81,21 @@ function CargoExpressContent(props) {
           title="Cargo Express"
           buttons={
             <Box inline bold verticalAlign={'middle'}>
+              {/* SS1984 REMOVAL START
               <AnimatedNumber value={Math.round(points)} />
               {' credits'}
+              SS1984 REMOVAL END */}
+              {/* SS1984 ADDITION START */}
+                <>
+                  <Box inline bold verticalAlign="middle" style={{ marginRight: '1em' }}>
+                    <span style={{ color: '#BA3692' }}>Plasma</span> cost: {current_plasma_cost}
+                  </Box>
+                  <Box inline bold verticalAlign="middle">
+                    <AnimatedNumber value={Math.round(points)} />
+                    {' credits'}
+                  </Box>
+                </>
+              {/* SS1984 ADDITION END */}
             </Box>
           }
         >


### PR DESCRIPTION
## Changelog

:cl:
fix: cargo ui plasmacost is shown at express console interface & pda intreface
/:cl:

****
- [x] Проверено на локалке
