### PR TITLE
qol: now casing description displays damage relative to gun they were chambered

### DIFF
--- a/code/datums/elements/caseless.dm
+++ b/code/datums/elements/caseless.dm
@@ -32,5 +32,5 @@
 	if(isgun(fired_from))
 		var/obj/item/gun/shot_from = fired_from
 		if(shot_from.chambered == shell)
-			shot_from.chambered = null //Nuke it. Nuke it now.
+			shot_from.set_chambered(null) // SS1984 EDIT, original: shot_from.chambered = null
 	QDEL_NULL(shell)

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -100,11 +100,25 @@
 	var/list/readout = list()
 	if(proj_damage_mult <= 0 || (initial_damage <= 0 && initial_stamina <= 0))
 		return "Our legal team has determined the offensive nature of these [span_warning(caliber)] rounds to be esoteric."
+	// SS1984 ADDITION START
+	var/was_chambered_desc = ""
+	var/dmg_desc_normal_stamina_text = "" // we need both stamina and normal, can't just append to was_chambered_desc as it would affect both at once
+	var/dmg_desc_normal_text = ""
+	var/obj/item/gun/was_chambered_at_gun = isnull(was_chambered_at) ? null : was_chambered_at.resolve()
+	if (!isnull(was_chambered_at_gun) && isgun(was_chambered_at_gun))
+		proj_damage_mult = was_chambered_at_gun.projectile_damage_multiplier
+		if (proj_damage_mult != 1)
+			was_chambered_desc = " from [span_bold(was_chambered_at_gun.name)]"
+			if (initial_damage)
+				dmg_desc_normal_text = " or [span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * 1) * pellets)]")] from other gun normally"
+			if (initial_stamina)
+				dmg_desc_normal_stamina_text = " or [span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * 1) * pellets)]")] from other gun normally"
+	// SS1984 ADDITION END
 	// No dividing by 0
 	if(initial_damage)
-		readout += "Most monkeys our legal team subjected to these [span_warning(caliber)] rounds succumbed to their wounds after [span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * proj_damage_mult) * pellets)] shot\s")] at point-blank, taking [span_warning("[pellets] shot\s")] per round."
+		readout += "Most monkeys our legal team subjected to these [span_warning(caliber)] rounds succumbed to their wounds after [span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * proj_damage_mult) * pellets)] shot\s[was_chambered_desc][dmg_desc_normal_text]")] at point-blank, taking [span_warning("[pellets] shot\s")] per round." // SS1984 EDIT, original:	readout += "Most monkeys our legal team subjected to these [span_warning(caliber)] rounds succumbed to their wounds after [span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * proj_damage_mult) * pellets)] shot\s")] at point-blank, taking [span_warning("[pellets] shot\s")] per round."
 	if(initial_stamina)
-		readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after [span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * proj_damage_mult) * pellets)] impact\s")] of these [span_warning("[caliber]")] rounds."
+		readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after [span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * proj_damage_mult) * pellets)] impact\s[was_chambered_desc][dmg_desc_normal_stamina_text]")] of these [span_warning("[caliber]")] rounds." // SS1984 EDIT, original: readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after [span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * proj_damage_mult) * pellets)] impact\s")] of these [span_warning("[caliber]")] rounds."
 	return readout.Join("\n") // Sending over a single string, rather than the whole list
 
 /obj/item/ammo_casing/update_icon_state()

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -83,7 +83,7 @@
 	var/proj_damage_mult = 1
 	if(!ispath(exam_proj) || pellets == 0)
 		return
-
+	var/datum/weakref/was_chambered_at_shared = was_chambered_at // SS1984 ADDITION
 	// are we in an ammo box?
 	if(isammobox(loc))
 		var/obj/item/ammo_box/our_box = loc
@@ -92,6 +92,10 @@
 			var/obj/item/gun/our_gun = our_box.loc
 			// grab the damage multiplier
 			proj_damage_mult = our_gun.projectile_damage_multiplier
+		// SS1984 ADDITION START
+		if(!isnull(our_box.was_chambered_at) && isgun(our_box.was_chambered_at))
+			was_chambered_at_shared = our_box.was_chambered_at
+		// SS1984 ADDITION END
 	// if not, are we just in a gun e.g. chambered
 	else if(isgun(loc))
 		var/obj/item/gun/our_gun = loc
@@ -104,7 +108,7 @@
 	var/was_chambered_desc = ""
 	var/dmg_desc_normal_stamina_text = "" // we need both stamina and normal, can't just append to was_chambered_desc as it would affect both at once
 	var/dmg_desc_normal_text = ""
-	var/obj/item/gun/was_chambered_at_gun = isnull(was_chambered_at) ? null : was_chambered_at.resolve()
+	var/obj/item/gun/was_chambered_at_gun = isnull(was_chambered_at_shared) ? null : was_chambered_at_shared.resolve()
 	if (!isnull(was_chambered_at_gun) && isgun(was_chambered_at_gun))
 		proj_damage_mult = was_chambered_at_gun.projectile_damage_multiplier
 		if (proj_damage_mult != 1)

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -93,7 +93,7 @@
 			// grab the damage multiplier
 			proj_damage_mult = our_gun.projectile_damage_multiplier
 		// SS1984 ADDITION START
-		if(!isnull(our_box.was_chambered_at) && isgun(our_box.was_chambered_at))
+		if(!isnull(our_box.was_chambered_at) && isweakref(our_box.was_chambered_at))
 			was_chambered_at_shared = our_box.was_chambered_at
 		// SS1984 ADDITION END
 	// if not, are we just in a gun e.g. chambered

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -209,7 +209,7 @@
 	var/obj/item/ammo_casing/A = get_round()
 	if(!A)
 		return
-
+	A.set_chamber_source(isnull(was_chambered_at) ? null : was_chambered_at.resolve()) // SS1984 ADDITION
 	A.forceMove(drop_location())
 	if(!user.is_holding(src) || !user.put_in_hands(A)) //incase they're using TK
 		A.bounce_away(FALSE, NONE)
@@ -270,5 +270,6 @@
 	var/turf/turf_mag = get_turf(src)
 	var/obj/item/ammo_casing/casing = get_round()
 	while (casing)
+		casing.set_chamber_source(isnull(was_chambered_at) ? null : was_chambered_at.resolve()) // SS1984 ADDITION
 		casing.forceMove(turf_mag)
 		casing = get_round()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -649,11 +649,5 @@
 /obj/item/gun/proc/before_firing(atom/target,mob/user)
 	return
 
-/obj/item/gun/proc/set_chambered(obj/item/ammo_casing/new_chambered)
-	chambered = new_chambered
-	if (isnull(chambered))
-		return
-	chambered.was_chambered_at = create_weakref()
-
 #undef FIRING_PIN_REMOVAL_DELAY
 #undef DUALWIELD_PENALTY_EXTRA_MULTIPLIER

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -36,7 +36,7 @@
 	var/can_unsuppress = TRUE
 	var/recoil = 0 //boom boom shake the room
 	var/clumsy_check = TRUE
-	var/obj/item/ammo_casing/chambered = null
+	VAR_FINAL/obj/item/ammo_casing/chambered = null // SS1984 EDIT use set_chambered, original: var/obj/item/ammo_casing/chambered = null
 	trigger_guard = TRIGGER_GUARD_NORMAL //trigger guard on the weapon, hulks can't fire them with their big meaty fingers
 	var/sawn_desc = null //description change if weapon is sawn-off
 	var/sawn_off = FALSE
@@ -133,7 +133,7 @@
 	if(gone == pin)
 		pin = null
 	if(gone == chambered)
-		chambered = null
+		set_chambered(null) // SS1984 EDIT, original: chambered = null
 		update_appearance()
 	if(gone == suppressed)
 		clear_suppressor()
@@ -648,6 +648,12 @@
 //Happens before the actual projectile creation
 /obj/item/gun/proc/before_firing(atom/target,mob/user)
 	return
+
+/obj/item/gun/proc/set_chambered(obj/item/ammo_casing/new_chambered)
+	chambered = new_chambered
+	if (isnull(chambered))
+		return
+	chambered.was_chambered_at = create_weakref()
 
 #undef FIRING_PIN_REMOVAL_DELAY
 #undef DUALWIELD_PENALTY_EXTRA_MULTIPLIER

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -309,7 +309,7 @@
 	if(istype(casing)) //there's a chambered round
 		if(QDELING(casing))
 			stack_trace("Trying to move a qdeleted casing of type [casing.type]!")
-			chambered = null
+			set_chambered(null) // SS1984 EDIT, original: chambered = null
 		else if(casing_ejector || !from_firing)
 			casing.forceMove(drop_location()) //Eject casing onto ground.
 			if(!QDELETED(casing))
@@ -402,7 +402,7 @@
 	if (chambered || !magazine)
 		return
 	if (magazine.ammo_count())
-		chambered = (bolt_type == BOLT_TYPE_OPEN && !bolt_locked) || bolt_type == BOLT_TYPE_NO_BOLT ? magazine.get_and_shuffle_round() : magazine.get_round()
+		set_chambered((bolt_type == BOLT_TYPE_OPEN && !bolt_locked) || bolt_type == BOLT_TYPE_NO_BOLT ? magazine.get_and_shuffle_round() : magazine.get_round()) // SS1984 EDIT, original: chambered = (bolt_type == BOLT_TYPE_OPEN && !bolt_locked) || bolt_type == BOLT_TYPE_NO_BOLT ? magazine.get_and_shuffle_round() : magazine.get_round()
 		if (bolt_type != BOLT_TYPE_OPEN && !(internal_magazine && bolt_type == BOLT_TYPE_NO_BOLT))
 			chambered.forceMove(src)
 		else
@@ -413,7 +413,7 @@
 /obj/item/gun/ballistic/proc/clear_chambered(datum/source)
 	SIGNAL_HANDLER
 	UnregisterSignal(chambered, COMSIG_MOVABLE_MOVED)
-	chambered = null
+	set_chambered(null) // SS1984 EDIT, original: chambered = null
 
 ///updates a bunch of racking related stuff and also handles the sound effects and the like
 /obj/item/gun/ballistic/proc/rack(mob/user = null)
@@ -468,7 +468,7 @@
 ///Handles all the logic of magazine ejection, if tac_load is set that magazine will be tacloaded in the place of the old eject
 /obj/item/gun/ballistic/proc/eject_magazine(mob/user, display_message = TRUE, obj/item/ammo_box/magazine/tac_load = null)
 	if(bolt_type == BOLT_TYPE_OPEN)
-		chambered = null
+		set_chambered(null) // SS1984 EDIT, original: chambered = null
 	if (magazine.ammo_count())
 		playsound(src, eject_sound, eject_sound_volume, eject_sound_vary)
 	else
@@ -548,7 +548,7 @@
 		chambered.forceMove(drop_location())
 		if(chambered != magazine?.stored_ammo[1])
 			magazine.stored_ammo -= chambered
-		chambered = null
+		set_chambered(null) // SS1984 EDIT, original: chambered = null
 
 	var/num_loaded = magazine?.attackby(ammo, user, silent = TRUE)
 	if (!num_loaded)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -150,7 +150,7 @@
 		return
 	if (!magazine)
 		magazine = new spawn_magazine_type(src)
-		magazine.set_chambered(src) // SS1984 ADDITION
+		magazine.set_chamber_source(src) // SS1984 ADDITION
 		if(!istype(magazine, accepted_magazine_type))
 			CRASH("[src] spawned with a magazine type that isn't allowed by its accepted_magazine_type!")
 	if(bolt_type == BOLT_TYPE_STANDARD || internal_magazine) //Internal magazines shouldn't get magazine + 1.
@@ -452,7 +452,7 @@
 		return FALSE
 	if(user.transferItemToLoc(AM, src))
 		magazine = AM
-		magazine.set_chambered(src) // SS1984 ADDITION
+		magazine.set_chamber_source(src) // SS1984 ADDITION
 		if (display_message)
 			balloon_alert(user, "[magazine_wording] loaded")
 		if (magazine.ammo_count())
@@ -844,7 +844,7 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 		if(!spawn_magazine_type)
 			return
 		magazine = new spawn_magazine_type(src)
-		magazine.set_chambered(src) // SS1984 ADDITION
+		magazine.set_chamber_source(src) // SS1984 ADDITION
 	chamber_round()
 	update_appearance()
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -150,6 +150,7 @@
 		return
 	if (!magazine)
 		magazine = new spawn_magazine_type(src)
+		magazine.set_chambered(src) // SS1984 ADDITION
 		if(!istype(magazine, accepted_magazine_type))
 			CRASH("[src] spawned with a magazine type that isn't allowed by its accepted_magazine_type!")
 	if(bolt_type == BOLT_TYPE_STANDARD || internal_magazine) //Internal magazines shouldn't get magazine + 1.
@@ -451,6 +452,7 @@
 		return FALSE
 	if(user.transferItemToLoc(AM, src))
 		magazine = AM
+		magazine.set_chambered(src) // SS1984 ADDITION
 		if (display_message)
 			balloon_alert(user, "[magazine_wording] loaded")
 		if (magazine.ammo_count())
@@ -842,6 +844,7 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 		if(!spawn_magazine_type)
 			return
 		magazine = new spawn_magazine_type(src)
+		magazine.set_chambered(src) // SS1984 ADDITION
 	chamber_round()
 	update_appearance()
 

--- a/code/modules/projectiles/guns/ballistic/bows/_bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/_bow.dm
@@ -45,19 +45,19 @@
 		return CLICK_ACTION_BLOCKING
 
 	user.put_in_hands(chambered)
-	chambered = magazine.get_round()
+	set_chambered(magazine.get_round()) // SS1984 EDIT, original: chambered = magazine.get_round()
 	update_appearance()
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/gun/ballistic/bow/proc/drop_arrow()
 	chambered.forceMove(drop_location())
-	chambered = magazine.get_round()
+	set_chambered(magazine.get_round()) // SS1984 EDIT, original: chambered = magazine.get_round()
 	update_appearance()
 
 /obj/item/gun/ballistic/bow/chamber_round(spin_cylinder, replace_new_round)
 	if(chambered || !magazine)
 		return
-	chambered = magazine.get_round()
+	set_chambered(magazine.get_round()) // SS1984 EDIT, original: chambered = magazine.get_round()
 	RegisterSignal(chambered, COMSIG_MOVABLE_MOVED, PROC_REF(clear_chambered))
 	update_appearance()
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -27,11 +27,11 @@
 	if(chambered)
 		UnregisterSignal(chambered, COMSIG_MOVABLE_MOVED)
 	if (spin_cylinder)
-		chambered = magazine.get_round()
+		set_chambered(magazine.get_round()) // SS1984 EDIT, original: chambered = magazine.get_round()
 	else
-		chambered = magazine.stored_ammo[1]
+		set_chambered(chambered = magazine.stored_ammo[1]) // SS1984 EDIT, original: chambered = magazine.stored_ammo[1]
 		if (ispath(chambered))
-			chambered = new chambered(src)
+			set_chambered(chambered = new chambered(src)) // SS1984 EDIT, original: chambered = new chambered(src)
 			magazine.stored_ammo[1] = chambered
 	if(chambered)
 		RegisterSignal(chambered, COMSIG_MOVABLE_MOVED, PROC_REF(clear_chambered))

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -29,9 +29,9 @@
 	if (spin_cylinder)
 		set_chambered(magazine.get_round()) // SS1984 EDIT, original: chambered = magazine.get_round()
 	else
-		set_chambered(chambered = magazine.stored_ammo[1]) // SS1984 EDIT, original: chambered = magazine.stored_ammo[1]
+		set_chambered(magazine.stored_ammo[1]) // SS1984 EDIT, original: chambered = magazine.stored_ammo[1]
 		if (ispath(chambered))
-			set_chambered(chambered = new chambered(src)) // SS1984 EDIT, original: chambered = new chambered(src)
+			set_chambered(new chambered(src)) // SS1984 EDIT, original: chambered = new chambered(src)
 			magazine.stored_ammo[1] = chambered
 	if(chambered)
 		RegisterSignal(chambered, COMSIG_MOVABLE_MOVED, PROC_REF(clear_chambered))

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -382,7 +382,7 @@
 	. = ..()
 	guns_left = 0
 	magazine = null
-	chambered = null
+	set_chambered(null) // SS1984 EDIT, original: chambered = null
 
 /obj/item/gun/ballistic/rifle/enchanted/proc/discard_gun(mob/living/user)
 	user.throw_item(pick(oview(7,get_turf(user))))

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -75,7 +75,7 @@
 	. = ..()
 	if(!(. & EMP_PROTECT_CONTENTS))
 		cell.use(round(cell.charge / severity))
-		chambered = null //we empty the chamber
+		set_chambered(null) // SS1984 EDIT, original: chambered = null
 		recharge_newshot() //and try to charge a new shot
 		update_appearance()
 
@@ -203,7 +203,7 @@
 	if(!chambered)
 		var/obj/item/ammo_casing/energy/AC = ammo_type[select]
 		if(cell.charge >= AC.e_cost) //if there's enough power in the cell cell...
-			chambered = AC //...prepare a new shot based on the current ammo type selected
+			set_chambered(AC) // SS1984 EDIT, original: chambered = AC //...prepare a new shot based on the current ammo type selected
 			if(!chambered.loaded_projectile)
 				chambered.newshot()
 
@@ -211,7 +211,7 @@
 	if(chambered && !chambered.loaded_projectile) //if loaded_projectile is null, i.e the shot has been fired...
 		var/obj/item/ammo_casing/energy/shot = chambered
 		cell.use(shot.e_cost)//... drain the cell cell
-	chambered = null //either way, released the prepared shot
+	set_chambered(null) // SS1984 EDIT, original: chambered = null
 	recharge_newshot() //try to charge a new shot
 
 /obj/item/gun/energy/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
@@ -233,7 +233,7 @@
 	fire_delay = shot.delay
 	if (shot.select_name && user)
 		balloon_alert(user, "set to [shot.select_name]")
-	chambered = null
+	set_chambered(null) // SS1984 EDIT, original: chambered = null
 	recharge_newshot(TRUE)
 	update_appearance()
 

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -102,7 +102,7 @@
 	. = ..()
 	charges = max_charges
 	if(ammo_type)
-		chambered = new ammo_type(src)
+		set_chambered(new ammo_type(src)) // SS1984 EDIT, original: chambered = new ammo_type(src)
 	if(can_charge)
 		START_PROCESSING(SSobj, src)
 	RegisterSignal(src, COMSIG_ITEM_RECHARGED, PROC_REF(instant_recharge))

--- a/code/modules/projectiles/guns/special/chem_gun.dm
+++ b/code/modules/projectiles/guns/special/chem_gun.dm
@@ -30,7 +30,7 @@
 
 /obj/item/gun/chem/Initialize(mapload)
 	. = ..()
-	chambered = new /obj/item/ammo_casing/chemgun(src)
+	set_chambered(new /obj/item/ammo_casing/chemgun(src)) // SS1984 EDIT, original: chambered = new /obj/item/ammo_casing/chemgun(src)
 	START_PROCESSING(SSobj, src)
 	create_reagents(90, OPENCONTAINER)
 

--- a/code/modules/projectiles/guns/special/syringe_gun.dm
+++ b/code/modules/projectiles/guns/special/syringe_gun.dm
@@ -31,7 +31,7 @@
 
 /obj/item/gun/syringe/Initialize(mapload)
 	. = ..()
-	chambered = new /obj/item/ammo_casing/syringegun(src)
+	set_chambered(new /obj/item/ammo_casing/syringegun(src)) // SS1984 EDIT, original: chambered = new /obj/item/ammo_casing/syringegun(src)
 	recharge_newshot()
 
 /obj/item/gun/syringe/apply_fantasy_bonuses(bonus)
@@ -52,9 +52,9 @@
 		return
 	//NOVA EDIT SMARTDARTS
 	if(istype(syringes[length(syringes)], /obj/item/reagent_containers/syringe/smartdart))
-		chambered = new /obj/item/ammo_casing/syringegun/dart(src)
+		set_chambered(new /obj/item/ammo_casing/syringegun/dart(src)) // SS1984 EDIT, original: chambered = new /obj/item/ammo_casing/syringegun/dart(src)
 	else
-		chambered = new /obj/item/ammo_casing/syringegun(src)
+		set_chambered(new /obj/item/ammo_casing/syringegun(src)) // SS1984 EDIT, original: chambered = new /obj/item/ammo_casing/syringegun(src)
 	//NOVA EDIT SMARTDARTS END
 	chambered.newshot()
 
@@ -189,7 +189,7 @@
 
 /obj/item/gun/syringe/dna/Initialize(mapload)
 	. = ..()
-	chambered = new /obj/item/ammo_casing/dnainjector(src)
+	set_chambered(new /obj/item/ammo_casing/dnainjector(src)) // SS1984 EDIT, original: chambered = new /obj/item/ammo_casing/dnainjector(src)
 
 /obj/item/gun/syringe/dna/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(istype(tool, /obj/item/dnainjector))

--- a/modular_nova/modules/clock_cult/code/items/weaponry.dm
+++ b/modular_nova/modules/clock_cult/code/items/weaponry.dm
@@ -204,7 +204,7 @@
 /obj/item/gun/ballistic/bow/clockwork/proc/recharge_bolt()
 	var/obj/item/ammo_casing/arrow/clockbolt/bolt = new
 	magazine.give_round(bolt)
-	chambered = bolt
+	set_chambered(bolt) // SS1984 EDIT, original: chambered = bolt
 	update_icon()
 
 

--- a/modular_nova/modules/marines/code/smartgun.dm
+++ b/modular_nova/modules/marines/code/smartgun.dm
@@ -128,8 +128,7 @@
 	if(istype(fired_from, /obj/item/gun))
 		var/obj/item/gun/shot_from = fired_from
 		if(shot_from.chambered == src)
-			shot_from.chambered = null //Nuke it. Nuke it now.
-	qdel(src)
+			shot_from.set_chambered(null) // SS1984 EDIT, original: shot_from.chambered = null //Nuke it. Nuke it now.
 	return TRUE
 
 /obj/item/ammo_casing/smart/update_icon_state()

--- a/modular_nova/modules/medical/code/smartdarts.dm
+++ b/modular_nova/modules/medical/code/smartdarts.dm
@@ -51,7 +51,7 @@
 
 /obj/item/gun/syringe/smartdart/Initialize(mapload)
 	. = ..()
-	chambered = new /obj/item/ammo_casing/syringegun/dart(src)
+	set_chambered(new /obj/item/ammo_casing/syringegun/dart(src)) // SS1984 EDIT, original: chambered = new /obj/item/ammo_casing/syringegun/dart(src)
 
 /obj/item/gun/syringe/smartdart/give_gun_safeties()
 	return

--- a/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/ammunition.dm
+++ b/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/ammunition.dm
@@ -1,0 +1,2 @@
+/obj/item/ammo_casing
+	var/datum/weakref/was_chambered_at

--- a/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/ammunition.dm
+++ b/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/ammunition.dm
@@ -1,2 +1,10 @@
 /obj/item/ammo_casing
 	var/datum/weakref/was_chambered_at
+
+/obj/item/ammo_casing/proc/set_chamber_source(obj/item/gun/new_gun)
+	if (!isnull(was_chambered_at))
+		if (was_chambered_at.resolve() == new_gun)
+			return
+	if (isnull(new_gun))
+		return
+	was_chambered_at = new_gun.create_weakref()

--- a/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/box_magazine.dm
+++ b/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/box_magazine.dm
@@ -1,0 +1,11 @@
+/obj/item/ammo_box
+	var/datum/weakref/was_chambered_at
+
+/obj/item/ammo_box/proc/set_chambered(obj/item/gun/new_gun)
+	if (!isnull(was_chambered_at))
+		if (was_chambered_at.resolve() == new_gun)
+			return
+		was_chambered_at.Destroy()
+	if (isnull(new_gun))
+		return
+	was_chambered_at = new_gun.create_weakref()

--- a/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/box_magazine.dm
+++ b/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/box_magazine.dm
@@ -1,11 +1,10 @@
 /obj/item/ammo_box
 	var/datum/weakref/was_chambered_at
 
-/obj/item/ammo_box/proc/set_chambered(obj/item/gun/new_gun)
+/obj/item/ammo_box/proc/set_chamber_source(obj/item/gun/new_gun)
 	if (!isnull(was_chambered_at))
 		if (was_chambered_at.resolve() == new_gun)
 			return
-		was_chambered_at.Destroy()
 	if (isnull(new_gun))
 		return
 	was_chambered_at = new_gun.create_weakref()

--- a/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/gun.dm
+++ b/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/gun.dm
@@ -1,0 +1,5 @@
+/obj/item/gun/proc/set_chambered(obj/item/ammo_casing/new_chambered)
+	chambered = new_chambered
+	if (isnull(chambered))
+		return
+	chambered.was_chambered_at = create_weakref()

--- a/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/gun.dm
+++ b/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/gun.dm
@@ -2,7 +2,7 @@
 	var/obj/item/ammo_casing/old_chambered = new_chambered
 	chambered = new_chambered
 	if (isnull(chambered))
-		if (!isnull(old_chambered.was_chambered_at))
+		if (!isnull(old_chambered) && !isnull(old_chambered.was_chambered_at))
 			old_chambered.was_chambered_at.Destroy()
 		return
 	if (!isnull(chambered.was_chambered_at))

--- a/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/gun.dm
+++ b/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/gun.dm
@@ -1,5 +1,4 @@
 /obj/item/gun/proc/set_chambered(obj/item/ammo_casing/new_chambered)
-	var/obj/item/ammo_casing/old_chambered = new_chambered
 	chambered = new_chambered
 	if (isnull(chambered))
 		return

--- a/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/gun.dm
+++ b/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/gun.dm
@@ -2,12 +2,5 @@
 	var/obj/item/ammo_casing/old_chambered = new_chambered
 	chambered = new_chambered
 	if (isnull(chambered))
-		if (!isnull(old_chambered) && !isnull(old_chambered.was_chambered_at))
-			old_chambered.was_chambered_at.Destroy()
 		return
-	if (!isnull(chambered.was_chambered_at))
-		if (chambered.was_chambered_at.resolve() == src)
-			return
-		chambered.was_chambered_at.Destroy()
-
-	chambered.was_chambered_at = create_weakref()
+	chambered.set_chamber_source(src)

--- a/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/gun.dm
+++ b/modular_ss220/modules/qol_casual_1984/combat_info_desc_gun/gun.dm
@@ -1,5 +1,13 @@
 /obj/item/gun/proc/set_chambered(obj/item/ammo_casing/new_chambered)
+	var/obj/item/ammo_casing/old_chambered = new_chambered
 	chambered = new_chambered
 	if (isnull(chambered))
+		if (!isnull(old_chambered.was_chambered_at))
+			old_chambered.was_chambered_at.Destroy()
 		return
+	if (!isnull(chambered.was_chambered_at))
+		if (chambered.was_chambered_at.resolve() == src)
+			return
+		chambered.was_chambered_at.Destroy()
+
 	chambered.was_chambered_at = create_weakref()

--- a/modular_ss220/modules/return_prs/microfusion/code/microfusion_energy_master.dm
+++ b/modular_ss220/modules/return_prs/microfusion/code/microfusion_energy_master.dm
@@ -80,7 +80,7 @@
 	. = ..()
 	if(!(. & EMP_PROTECT_CONTENTS))
 		cell.use(round(cell.charge / severity))
-		chambered = null //we empty the chamber
+		set_chambered(null)
 		recharge_newshot() //and try to charge a new shot
 		update_appearance()
 
@@ -151,7 +151,7 @@
 /obj/item/gun/microfusion/recharge_newshot()
 	if (!microfusion_lens || !cell || !phase_emitter)
 		return
-	chambered = microfusion_lens
+	set_chambered(microfusion_lens)
 	if(!chambered.loaded_projectile)
 		chambered.newshot()
 
@@ -159,7 +159,7 @@
 	if(chambered && !chambered.loaded_projectile && cell) //if loaded_projectile is null, i.e the shot has been fired...
 		var/obj/item/ammo_casing/energy/shot = chambered
 		cell.use(shot.e_cost + extra_power_usage)//... drain the cell
-	chambered = null //either way, released the prepared shot
+	set_chambered(null)
 	recharge_newshot() //try to charge a new shot
 
 /obj/item/gun/microfusion/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9443,6 +9443,7 @@
 #include "modular_ss220\modules\qol_casual_1984\atmos_engi_skillchip\atmospheric_technician.dm"
 #include "modular_ss220\modules\qol_casual_1984\combat_info_desc_gun\ammunition.dm"
 #include "modular_ss220\modules\qol_casual_1984\combat_info_desc_gun\gun.dm"
+#include "modular_ss220\modules\qol_casual_1984\combat_info_desc_gun\box_magazine.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\techweb_types.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\machine_circuits.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\interdyne_ds2_rnd.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9441,6 +9441,8 @@
 #include "modular_ss220\modules\qol_casual_1984\healthanalyzer_autolathe\medical_designs.dm"
 #include "modular_ss220\modules\qol_casual_1984\nanodrug_pills\medical.dm"
 #include "modular_ss220\modules\qol_casual_1984\atmos_engi_skillchip\atmospheric_technician.dm"
+#include "modular_ss220\modules\qol_casual_1984\combat_info_desc_gun\ammunition.dm"
+#include "modular_ss220\modules\qol_casual_1984\combat_info_desc_gun\gun.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\techweb_types.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\machine_circuits.dm"
 #include "modular_ss220\modules\ghostroles_stuff\ds2_interdyne_shared\interdyne_ds2_rnd.dm"


### PR DESCRIPTION
## Скриншоты

### Пуля вынутая из пушки с модификатором 0.5

<img width="508" height="214" alt="image" src="https://github.com/user-attachments/assets/934da526-5fb3-45fc-9bdd-d267c9e1a80b" />

### Магазин вынутый из пушки с модификатором 0.5

<img width="518" height="352" alt="image" src="https://github.com/user-attachments/assets/90caf344-d5d0-485a-889e-559034e87af9" />

### Магазин никуда еще не загруженный / загруженный в оружие с модификатором 1

<img width="488" height="296" alt="image" src="https://github.com/user-attachments/assets/6ea63053-5d4d-4661-a7b4-71be75e0e4cb" />

## Changelog

:cl:
qol: Now once casing left from gun that had custom projectile damage modifier, it's combat information displays info relative to previous gun. Also shows for normal modifier as well
/:cl:

****
- [x] Проверено на локалке
