### PR TITLE
admin: Dynamic admin height

### DIFF
--- a/tgui/packages/tgui/interfaces/DynamicAdmin.tsx
+++ b/tgui/packages/tgui/interfaces/DynamicAdmin.tsx
@@ -730,7 +730,7 @@ export const DynamicAdmin = () => {
     <Window
       title="Dynamic Admin Panel"
       width={currentTab === TABS.Rulesets ? 800 : 500}
-      height={currentTab === TABS.Rulesets ? 600 : 400}
+      height={currentTab === TABS.Rulesets ? 600 : 500} // SS1984 EDIT, original: height={currentTab === TABS.Rulesets ? 600 : 400}
     >
       <Window.Content>
         <Section


### PR DESCRIPTION
## Changelog

:cl:
admin: Dynamic admin panel height increased in tabs that are not rulesets from 400 to 500
/:cl:
