### PR TITLE
add: health analyzer is default in technodes

### DIFF
--- a/modular_ss220/modules/qol_casual_1984/healthanalyzer_autolathe/biology_nodes.dm
+++ b/modular_ss220/modules/qol_casual_1984/healthanalyzer_autolathe/biology_nodes.dm
@@ -1,0 +1,3 @@
+/datum/techweb_node/bio_scan/New()
+	design_ids -= "healthanalyzer"
+	return ..()

--- a/modular_ss220/modules/qol_casual_1984/healthanalyzer_autolathe/medbay_nodes.dm
+++ b/modular_ss220/modules/qol_casual_1984/healthanalyzer_autolathe/medbay_nodes.dm
@@ -1,0 +1,3 @@
+/datum/techweb_node/medbay_equip/New()
+	design_ids += "healthanalyzer"
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9479,6 +9479,8 @@
 #include "modular_ss220\modules\qol_casual_1984\autopin_jetpack_module\_module.dm"
 #include "modular_ss220\modules\qol_casual_1984\autopin_jetpack_module\mod_control.dm"
 #include "modular_ss220\modules\qol_casual_1984\healthanalyzer_autolathe\medical_designs.dm"
+#include "modular_ss220\modules\qol_casual_1984\healthanalyzer_autolathe\biology_nodes.dm"
+#include "modular_ss220\modules\qol_casual_1984\healthanalyzer_autolathe\medbay_nodes.dm"
 #include "modular_ss220\modules\qol_casual_1984\nanodrug_pills\medical.dm"
 #include "modular_ss220\modules\qol_casual_1984\atmos_engi_skillchip\atmospheric_technician.dm"
 #include "modular_ss220\modules\qol_casual_1984\combat_info_desc_gun\ammunition.dm"


### PR DESCRIPTION
## Changelog

:cl:
add: Basic Health Analyzer is now default at medbay equipment technode (spawn in med techfab) from start
/:cl:

****
- [x] Проверено на локалке
