### PR TITLE
fix: some emotes use default human sounds if species doesnt have custom

### DIFF
--- a/modular_ss220/modules/emote_sounds/emotes.dm
+++ b/modular_ss220/modules/emote_sounds/emotes.dm
@@ -1,0 +1,84 @@
+/datum/species/get_scream_sound(mob/living/carbon/human/someone)
+	if(someone.physique == MALE)
+		if(prob(1))
+			return 'sound/mobs/humanoids/human/scream/wilhelm_scream.ogg'
+		return pick(
+			'sound/mobs/humanoids/human/scream/malescream_1.ogg',
+			'sound/mobs/humanoids/human/scream/malescream_2.ogg',
+			'sound/mobs/humanoids/human/scream/malescream_3.ogg',
+			'sound/mobs/humanoids/human/scream/malescream_4.ogg',
+			'sound/mobs/humanoids/human/scream/malescream_5.ogg',
+			'sound/mobs/humanoids/human/scream/malescream_6.ogg',
+		)
+
+	return pick(
+		'sound/mobs/humanoids/human/scream/femalescream_1.ogg',
+		'sound/mobs/humanoids/human/scream/femalescream_2.ogg',
+		'sound/mobs/humanoids/human/scream/femalescream_3.ogg',
+		'sound/mobs/humanoids/human/scream/femalescream_4.ogg',
+		'sound/mobs/humanoids/human/scream/femalescream_5.ogg',
+	)
+
+/datum/species/get_cough_sound(mob/living/carbon/human/someone)
+	if(someone.gender == FEMALE) // NOVA EDIT CHANGE - ORIGINAL: if(human.physique == FEMALE)
+		return pick(
+			'sound/mobs/humanoids/human/cough/female_cough1.ogg',
+			'sound/mobs/humanoids/human/cough/female_cough2.ogg',
+			'sound/mobs/humanoids/human/cough/female_cough3.ogg',
+			'sound/mobs/humanoids/human/cough/female_cough4.ogg',
+			'sound/mobs/humanoids/human/cough/female_cough5.ogg',
+			'sound/mobs/humanoids/human/cough/female_cough6.ogg',
+		)
+	return pick(
+		'sound/mobs/humanoids/human/cough/male_cough1.ogg',
+		'sound/mobs/humanoids/human/cough/male_cough2.ogg',
+		'sound/mobs/humanoids/human/cough/male_cough3.ogg',
+		'sound/mobs/humanoids/human/cough/male_cough4.ogg',
+		'sound/mobs/humanoids/human/cough/male_cough5.ogg',
+		'sound/mobs/humanoids/human/cough/male_cough6.ogg',
+	)
+
+
+/datum/species/get_cry_sound(mob/living/carbon/human/someone)
+	if(someone.physique == FEMALE)
+		return pick(
+			'sound/mobs/humanoids/human/cry/female_cry1.ogg',
+			'sound/mobs/humanoids/human/cry/female_cry2.ogg',
+		)
+	return pick(
+		'sound/mobs/humanoids/human/cry/male_cry1.ogg',
+		'sound/mobs/humanoids/human/cry/male_cry2.ogg',
+		'sound/mobs/humanoids/human/cry/male_cry3.ogg',
+	)
+
+/datum/species/get_sneeze_sound(mob/living/carbon/human/someone)
+	if(someone.physique == FEMALE)
+		return 'sound/mobs/humanoids/human/sneeze/female_sneeze1.ogg'
+	return 'sound/mobs/humanoids/human/sneeze/male_sneeze1.ogg'
+
+/datum/species/get_laugh_sound(mob/living/carbon/human/someone)
+	if(someone.physique == FEMALE)
+		return 'sound/mobs/humanoids/human/laugh/womanlaugh.ogg'
+	return pick(
+		'sound/mobs/humanoids/human/laugh/manlaugh1.ogg',
+		'sound/mobs/humanoids/human/laugh/manlaugh2.ogg',
+	)
+
+/datum/species/get_sigh_sound(mob/living/carbon/human/someone)
+	// if something override it, it's fine, because they don't call base
+	if(someone.physique == FEMALE)
+		return SFX_FEMALE_SIGH
+	return SFX_MALE_SIGH
+
+/datum/species/get_sniff_sound(mob/living/carbon/human/someone)
+	if(someone.physique == FEMALE)
+		return 'sound/mobs/humanoids/human/sniff/female_sniff.ogg'
+	return 'sound/mobs/humanoids/human/sniff/male_sniff.ogg'
+
+/datum/species/get_snore_sound(mob/living/carbon/human/someone)
+	if(someone.physique == FEMALE)
+		return SFX_SNORE_FEMALE
+	return SFX_SNORE_MALE
+
+/datum/species/get_hiss_sound(mob/living/carbon/human/someone)
+	return 'sound/mobs/humanoids/human/hiss/human_hiss.ogg'

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9494,4 +9494,5 @@
 #include "modular_ss220\modules\rust_g_custom\test.dm"
 #include "modular_ss220\modules\admin_stuff\man_up\admin.dm"
 #include "modular_ss220\modules\admin_stuff\man_up\adminhelp.dm"
+#include "modular_ss220\modules\emote_sounds\emotes.dm"
 // END_INCLUDE


### PR DESCRIPTION
На ТГ всем прописаны звуки, так что это скорее фикс новы, чем тг

## Changelog

:cl:
fix: Now if species doesnt have custom basic emotes sounds, then it use human sounds
/:cl:

****
- [x] Проверено на локалке