### PR TITLE
fix: eyelids with disabled blinking not shown

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -485,6 +485,11 @@
 /// Animates one eyelid at a time, thanks BYOND and thanks animation chains
 /obj/item/organ/eyes/proc/animate_eyelid(obj/effect/abstract/eyelid_effect/eyelid, mob/living/carbon/human/parent, sync_blinking = TRUE, list/anim_times = null)
 	. = list()
+	// SS1984 ADDITION START
+	if(CONFIG_GET(flag/disable_blinking))
+		animate(eyelid, alpha = 0, time = 0, loop = 0) // only eyelid, nothing more
+		return .
+	// SS1984 ADDITION END
 	var/prevent_loops = HAS_TRAIT(parent, TRAIT_PREVENT_BLINK_LOOPS)
 	animate(eyelid, alpha = 0, time = 0, loop = (prevent_loops ? 0 : -1))
 
@@ -538,7 +543,7 @@
 		addtimer(CALLBACK(src, PROC_REF(animate_eyelids), owner), blink_delay + duration)
 
 /obj/item/organ/eyes/proc/animate_eyelids(mob/living/carbon/human/parent)
-	if(CONFIG_GET(flag/disable_blinking)) return // NOVA EDIT ADDITION - CONFIG BLINKING
+	// SS1984 REMOVAL if(CONFIG_GET(flag/disable_blinking)) return // NOVA EDIT ADDITION - CONFIG BLINKING
 	var/sync_blinking = synchronized_blinking && (parent.get_organ_loss(ORGAN_SLOT_BRAIN) < BRAIN_DAMAGE_ASYNC_BLINKING)
 	// Randomize order for unsynched animations
 	if (sync_blinking || prob(50))


### PR DESCRIPTION
Куклы не моргают если blinking выключен, но их зрачки видны

## Скриншоты

<img width="583" height="375" alt="image" src="https://github.com/user-attachments/assets/4ed8b197-e563-48d0-b58d-60d96b34a7a8" />

## Changelog

:cl:
fix: Eyelids now shown even if blinking is disabled
/:cl:

****
- [x] Проверено на локалке
