### PR TITLE
fix: Replaces most game font usages to MS Serif to fix cyrilic issues

### DIFF
--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -17,16 +17,16 @@
  * For example: MAPTEXT_PIXELLARI("<span style='font-size: 24pt'>Some large maptext here</span>")
  */
 /// Large size (ie: context tooltips) - Size options: 12pt 24pt.
-#define MAPTEXT_PIXELLARI(text) {"<span style='font-family: \"Pixellari\"; font-size: 12pt; -dm-text-outline: 1px black'>[##text]</span>"}
+#define MAPTEXT_PIXELLARI(text) {"<span style='font-family: \"MS Serif\"; font-size: 12pt; -dm-text-outline: 1px black'>[##text]</span>"} // SS1984 EDIT, original: #define MAPTEXT_PIXELLARI(text) {"<span style='font-family: \"Pixellari\"; font-size: 12pt; -dm-text-outline: 1px black'>[##text]</span>"}
 
 /// Standard size (ie: normal runechat) - Size options: 6pt 12pt 18pt.
-#define MAPTEXT_GRAND9K(text) {"<span style='font-family: \"Grand9K Pixel\"; font-size: 6pt; -dm-text-outline: 1px black'>[##text]</span>"}
+#define MAPTEXT_GRAND9K(text) {"<span style='font-family: \"MS Serif\"; font-size: 6pt; -dm-text-outline: 1px black'>[##text]</span>"} // SS1984 EDIT, original: #define MAPTEXT_GRAND9K(text) {"<span style='font-family: \"Grand9K Pixel\"; font-size: 6pt; -dm-text-outline: 1px black'>[##text]</span>"}
 
 /// Small size. (ie: context subtooltips, spell delays) - Size options: 12pt 24pt.
-#define MAPTEXT_TINY_UNICODE(text) {"<span style='font-family: \"TinyUnicode\"; font-size: 12pt; line-height: 0.75; -dm-text-outline: 1px black'>[##text]</span>"}
+#define MAPTEXT_TINY_UNICODE(text) {"<span style='font-family: \"MS Serif\"; font-size: 12pt; line-height: 0.75; -dm-text-outline: 1px black'>[##text]</span>"} // SS1984 EDIT, original: #define MAPTEXT_TINY_UNICODE(text) {"<span style='font-family: \"TinyUnicode\"; font-size: 12pt; line-height: 0.75; -dm-text-outline: 1px black'>[##text]</span>"}
 
 /// Smallest size. (ie: whisper runechat) - Size options: 6pt 12pt 18pt.
-#define MAPTEXT_SPESSFONT(text) {"<span style='font-family: \"Spess Font\"; font-size: 6pt; line-height: 1.4; -dm-text-outline: 1px black'>[##text]</span>"}
+#define MAPTEXT_SPESSFONT(text) {"<span style='font-family: \"MS Serif\"; font-size: 6pt; line-height: 1.4; -dm-text-outline: 1px black'>[##text]</span>"} // SS1984 EDIT, original: #define MAPTEXT_SPESSFONT(text) {"<span style='font-family: \"Spess Font\"; font-size: 6pt; line-height: 1.4; -dm-text-outline: 1px black'>[##text]</span>"}
 
 /**
  * Prepares a text to be used for maptext, using a variable size font.

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -119,12 +119,12 @@ window "mapwindow"
 		size = 640x480
 		anchor1 = 0,0
 		anchor2 = 100,100
-		font-family = "Grand9K Pixel"
+		font-family = "MS Serif"
 		font-size = 6
 		is-default = true
 		right-click = true
 		saved-params = "zoom;letterbox;zoom-mode"
-        style = "img.icon { width: auto; height: auto } .center { text-align: center; } .maptext { font-family: 'Grand9K Pixel'; font-size: 6pt; -dm-text-outline: 1px black; color: white; line-height: 1.0; } .command_headset { font-weight: bold; } .context { font-family: 'Pixellari'; font-size: 12pt; -dm-text-outline: 1px black; }  .subcontext { font-family: 'TinyUnicode'; font-size: 12pt; line-height: 0.75; } .small { font-family: 'Spess Font'; font-size: 6pt; line-height: 1.4; } .big { font-family: 'Pixellari'; font-size: 12pt; } .reallybig { font-size: 12pt; } .extremelybig { font-size: 12pt; } .greentext { color: #00FF00; font-size: 6pt; } .redtext { color: #FF0000; font-size: 6pt; } .clown { color: #FF69BF; font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-family: 'MS Serif'; font-size: 6px; }"
+        style = "img.icon { width: auto; height: auto } .center { text-align: center; } .maptext { font-family: 'MS Serif'; font-size: 6pt; -dm-text-outline: 1px black; color: white; line-height: 1.0; } .command_headset { font-weight: bold; } .context { font-family: 'MS Serif'; font-size: 12pt; -dm-text-outline: 1px black; }  .subcontext { font-family: 'MS Serif'; font-size: 12pt; line-height: 0.75; } .small { font-family: 'MS Serif'; font-size: 6pt; line-height: 1.4; } .big { font-family: 'MS Serif'; font-size: 12pt; } .reallybig { font-size: 12pt; } .extremelybig { font-size: 12pt; } .greentext { color: #00FF00; font-size: 6pt; } .redtext { color: #FF0000; font-size: 6pt; } .clown { color: #FF69BF; font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-family: 'MS Serif'; font-size: 6px; }"
 	elem "nova_title_browser"
 		type = BROWSER
 		pos = 0,0


### PR DESCRIPTION
По логичным причинам проверить абсолютно все тут не выйдет сразу, но базовые вещи вроде исправились в заряднике когда окончание заряда - пишет корректно на кириллице

## Changelog

:cl:
fix: Replaces most game font usages to MS Serif to fix cyrillic issues
/:cl:

****
- [x] Проверено на локалке
