### PR TITLE
spellcheck: fix non mime clap localize

### DIFF
--- a/modular_ss220/modules/localization_modular/emotes_localization/emotes.dm
+++ b/modular_ss220/modules/localization_modular/emotes_localization/emotes.dm
@@ -342,7 +342,7 @@
 /datum/emote/living/carbon/clap
 	name = "хлопать"
 	message = "хлопа%(ет,ют)%!"
-	message = "бесшумно хлопа%(ет,ют)%!"
+	message_mime = "бесшумно хлопа%(ет,ют)%!"
 
 /datum/emote/living/carbon/crack
 	name = "хрустеть кистями"


### PR DESCRIPTION
## Changelog

:cl:
spellcheck: Fix non-mime clap emote message
/:cl: