### PR TITLE
fix: no double wag emote

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -130,11 +130,13 @@
 
 /datum/emote/living/carbon/human/wag/select_message_type(mob/user, intentional)
 	. = ..()
-	var/obj/item/organ/tail/oranges_accessory = user.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
-	if(oranges_accessory.wag_flags & WAG_WAGGING)
-		. = "stops wagging " + message
-	else
-		. = "wags " + message
+	// SS1984 REMOVAL START
+	// var/obj/item/organ/tail/oranges_accessory = user.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+	// if(oranges_accessory.wag_flags & WAG_WAGGING)
+	// 	. = "stops wagging " + message
+	// else
+	// 	. = "wags " + message
+	// SS1984 REMOVAL END
 
 /datum/emote/living/carbon/human/wag/can_run_emote(mob/user, status_check, intentional, params)
 	var/obj/item/organ/tail/tail = user.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -130,13 +130,11 @@
 
 /datum/emote/living/carbon/human/wag/select_message_type(mob/user, intentional)
 	. = ..()
-	// SS1984 REMOVAL START
-	// var/obj/item/organ/tail/oranges_accessory = user.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
-	// if(oranges_accessory.wag_flags & WAG_WAGGING)
-	// 	. = "stops wagging " + message
-	// else
-	// 	. = "wags " + message
-	// SS1984 REMOVAL END
+	var/obj/item/organ/tail/oranges_accessory = user.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+	if(oranges_accessory.wag_flags & WAG_WAGGING)
+		. = "прекращает " + message // SS1984 EDIT, original: . = "stops wagging " + message
+	else
+		. = "начинает " + message // SS1984 EDIT, original: . = "wags " + message
 
 /datum/emote/living/carbon/human/wag/can_run_emote(mob/user, status_check, intentional, params)
 	var/obj/item/organ/tail/tail = user.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)

--- a/modular_ss220/modules/localization_modular/emotes_localization/emotes.dm
+++ b/modular_ss220/modules/localization_modular/emotes_localization/emotes.dm
@@ -495,8 +495,8 @@
 
 /datum/emote/living/carbon/human/wag
 	name = "вилять хвостом"
-	message = "виля%(ет,ют)% хвостом."
-	message_mime = "бесшумно виля%(ет,ют)% хвостом."
+	message = "вилять хвостом." // those are special ones, look at code\modules\mob\living\carbon\human\emote.dm around 135 line (might change line by upstreams)
+	message_mime = "бесшумно вилять хвостом."
 
 /datum/emote/living/carbon/human/wing
 	name = "расправить крылья"


### PR DESCRIPTION
## Changelog

:cl:
fix: Wag emote no longer sends non-localized message part
/:cl:

****
- [x] Проверено на локалке