### PR TITLE
qol: security record console specify reason on change status

### DIFF
--- a/code/game/machinery/computer/records/security.dm
+++ b/code/game/machinery/computer/records/security.dm
@@ -196,8 +196,8 @@
 
 			// SS1984 ADDITION START
 			var/reason_text = tgui_input_text(user, "Comment:", "Add comment", "", MAX_DESC_LEN, encode = FALSE)
-			if(!reason_text)
-				reason_text = "" // it's valid
+			if(isnull(reason_text))
+				return FALSE
 
 			var/found_rank
 			var/found_name

--- a/code/game/machinery/computer/records/security.dm
+++ b/code/game/machinery/computer/records/security.dm
@@ -193,10 +193,41 @@
 			var/wanted_status = params["status"]
 			if(!wanted_status || !(wanted_status in WANTED_STATUSES()))
 				return FALSE
-			if(wanted_status == WANTED_ARREST && !length(target.crimes))
-				return FALSE
 
-			investigate_log("[target.name] has been set from [target.wanted_status] to [wanted_status] by [key_name(usr)].", INVESTIGATE_RECORDS)
+			// SS1984 ADDITION START
+			var/reason_text = tgui_input_text(user, "Comment:", "Add comment", "", MAX_DESC_LEN, encode = FALSE)
+			if(!reason_text)
+				reason_text = "" // it's valid
+
+			var/found_rank
+			var/found_name
+			var/mob/living/carbon/human/human_user = user
+			if (human_user)
+				var/obj/item/id_slot = human_user.get_item_by_slot(ITEM_SLOT_ID)
+				if(id_slot)
+					var/id_card = id_slot?.GetID()
+					if(id_card)
+						var/retrieved_job = retrieve_relevant_job(human_user, id_card, TRUE)
+						if (!retrieved_job)
+							retrieved_job = retrieve_relevant_job(human_user, id_card, FALSE)
+						if (retrieved_job)
+							found_rank = retrieved_job
+						var/obj/item/card/id/id_card_casted = id_card
+						if (id_card_casted)
+							found_name = id_card_casted.registered_name
+			if (!found_name)
+				found_name = "Unknown"
+
+			var/datum/crime/new_crime = new(author = "SecHUD", details = "Set status from [target.wanted_status] to [wanted_status] by [found_name][found_rank ? " ([found_rank])" : ""]. Comment: [reason_text]")
+			target.crimes += new_crime
+			investigate_log("SecHUD status change for [target.name] from [target.wanted_status] to [wanted_status] by [key_name(human_user)]. Comment: [reason_text]", INVESTIGATE_RECORDS)
+			// SS1984 ADDITION END
+			// SS1984 REMOVAL START
+			// if(wanted_status == WANTED_ARREST && !length(target.crimes))
+			// 	return FALSE
+
+			// investigate_log("[target.name] has been set from [target.wanted_status] to [wanted_status] by [key_name(usr)].", INVESTIGATE_RECORDS)
+			// SS1984 REMOVAL END
 			target.wanted_status = wanted_status
 
 			update_matching_security_huds(target.name)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -305,8 +305,8 @@
 				// SS1984 REMOVAL END
 				// SS1984 ADDITION START
 				var/reason_text = tgui_input_text(usr, "Comment:", "Add comment", "", MAX_DESC_LEN, encode = FALSE)
-				if(!reason_text)
-					reason_text = "" // it's valid
+				if(isnull(reason_text))
+					return
 
 				var/id_card
 				var/found_rank

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
@@ -121,7 +121,7 @@ const RecordInfo = (props) => {
                 return (
                   <Button
                     color={isSelected ? CRIMESTATUS2COLOR[button] : 'grey'}
-                    disabled={button === 'Arrest' && !hasValidCrimes}
+                    // SS1984 REMOVAL disabled={button === 'Arrest' && !hasValidCrimes}
                     icon={isSelected ? 'check' : ''}
                     key={index}
                     onClick={() =>


### PR DESCRIPTION
## Changelog

:cl:
qol: Security records console now requires reason for changing status (could be empty) - so it will log all status changes
fix: Cancel button now properly work on sechud status change
/:cl:

****
- [x] Проверено на локалке
