### PR TITLE
server: trying to minimize harddel time from config

### DIFF
--- a/config/config_server.txt
+++ b/config/config_server.txt
@@ -530,10 +530,10 @@ DRIFT_PROFILE_DELAY 150
 #ADMIN_2FA_URL https://example.com/id/%ID%
 
 ## How long in seconds after which a hard delete is treated as causing lag. This can be a float and supports a precision as low as nanoseconds.
-HARD_DELETES_OVERRUN_THRESHOLD 0.5
+HARD_DELETES_OVERRUN_THRESHOLD 0.05
 
 ## Once a typepath causes overrun from hard deletes this many times, stop hard deleting it on garbage collection failures. (set to 0 to disable)
-HARD_DELETES_OVERRUN_LIMIT 100
+HARD_DELETES_OVERRUN_LIMIT 10
 
 ## The URL to the webhook for adminhelps to relay the urgent ahelp message to
 ## If not set, will disable urgent ahelps.


### PR DESCRIPTION
Скорее всего поможет исправить спонтанные зависания на условных 3 секунды, будет ли работать как задумано надо будет смотреть
В идеальном мире, нужно найти от чего происходят hard-delы, но на локалке с REFERENCE_TRACKING_STANDARD проблему воспроизвести не получается, поэтому как вариант попробовать ее реализовывать
В теории:
в лучшем случае может остаться несколько ref-oв в памяти, которые никогда не будут чиститься (просто в ОЗУ лежать будут где-то в swapfile в идеале)
в худшем случае, они помимо этого могут вызывать аномалии в контроллерах, т.к. могут обрабатываться (похожее было с Fast Processing, если это было истинной причиной)