### PR TITLE
add: prison plate circuit + technode + upgrades

### DIFF
--- a/code/game/machinery/prisonlabor.dm
+++ b/code/game/machinery/prisonlabor.dm
@@ -53,10 +53,12 @@
 	update_appearance()
 	to_chat(user, span_notice("You start pressing a new license plate!"))
 
-	if(!do_after(user, 4 SECONDS * speed_modifier, target = src)) // SS1984 EDIT, original: if(!do_after(user, 4 SECONDS, target = src))
+	if(!do_after(user, 4 SECONDS * speed_modifier, target = src, extra_checks = CALLBACK(src, PROC_REF(still_processing)))) // SS1984 EDIT, original: if(!do_after(user, 4 SECONDS, target = src))
 		pressing = FALSE
 		update_appearance()
 		return FALSE
+	if (!pressing) // SS1984 ADDITION
+		return FALSE // SS1984
 
 	use_energy(active_power_usage)
 	to_chat(user, span_notice("You finish pressing a new license plate!"))

--- a/code/game/machinery/prisonlabor.dm
+++ b/code/game/machinery/prisonlabor.dm
@@ -53,7 +53,7 @@
 	update_appearance()
 	to_chat(user, span_notice("You start pressing a new license plate!"))
 
-	if(!do_after(user, 4 SECONDS, target = src))
+	if(!do_after(user, 4 SECONDS * speed_modifier, target = src)) // SS1984 EDIT, original: if(!do_after(user, 4 SECONDS, target = src))
 		pressing = FALSE
 		update_appearance()
 		return FALSE

--- a/modular_ss220/modules/security_minor_1984/licensepress_circuit/machine_circuitboards.dm
+++ b/modular_ss220/modules/security_minor_1984/licensepress_circuit/machine_circuitboards.dm
@@ -1,0 +1,9 @@
+/obj/item/circuitboard/machine/plate_press
+	name = "License plate press"
+	greyscale_colors = CIRCUIT_COLOR_SECURITY
+	build_path = /obj/machinery/plate_press
+	req_components = list(
+		/datum/stock_part/matter_bin = 1,
+		/datum/stock_part/servo = 1,
+	)
+	needs_anchored = TRUE

--- a/modular_ss220/modules/security_minor_1984/licensepress_circuit/misc_designs.dm
+++ b/modular_ss220/modules/security_minor_1984/licensepress_circuit/misc_designs.dm
@@ -1,5 +1,5 @@
 /datum/design/board/licensepress
-	name = "License plate press"
+	name = "License plate press board"
 	desc = "You know, we're making a lot of license plates for a station with literally no cars in it."
 	id = "licensepress"
 	build_path = /obj/item/circuitboard/machine/plate_press

--- a/modular_ss220/modules/security_minor_1984/licensepress_circuit/misc_designs.dm
+++ b/modular_ss220/modules/security_minor_1984/licensepress_circuit/misc_designs.dm
@@ -1,0 +1,9 @@
+/datum/design/board/licensepress
+	name = "License plate press"
+	desc = "You know, we're making a lot of license plates for a station with literally no cars in it."
+	id = "licensepress"
+	build_path = /obj/item/circuitboard/machine/plate_press
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_SECURITY
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY

--- a/modular_ss220/modules/security_minor_1984/licensepress_circuit/prisonlabor.dm
+++ b/modular_ss220/modules/security_minor_1984/licensepress_circuit/prisonlabor.dm
@@ -10,10 +10,10 @@
 	speed_modifier = DEFAULT_PLATE_PRESS_SPEED_MOD
 
 	for(var/datum/stock_part/matter_bin/new_matter_bin in component_parts)
-		speed_modifier -= (new_matter_bin.tier * 0.025)
+		speed_modifier -= ((new_matter_bin.tier - 1) * 0.025)
 
 	for(var/datum/stock_part/servo/new_servo in component_parts)
-		speed_modifier -= (new_servo.tier * 0.05)
+		speed_modifier -= ((new_servo.tier - 1) * 0.05)
 
 	// so tier 4 bin and tier 4 servo gives
 	// 4 * 0.025 + 4 * 0.05 = 0.3 modifier reduce

--- a/modular_ss220/modules/security_minor_1984/licensepress_circuit/prisonlabor.dm
+++ b/modular_ss220/modules/security_minor_1984/licensepress_circuit/prisonlabor.dm
@@ -1,4 +1,4 @@
-#define DEFAULT_PLATE_PRESS_SPEED_MOD = 1.0
+#define DEFAULT_PLATE_PRESS_SPEED_MOD 1.0
 
 /obj/machinery/plate_press
 	circuit = /obj/item/circuitboard/machine/plate_press

--- a/modular_ss220/modules/security_minor_1984/licensepress_circuit/prisonlabor.dm
+++ b/modular_ss220/modules/security_minor_1984/licensepress_circuit/prisonlabor.dm
@@ -10,10 +10,10 @@
 	speed_modifier = DEFAULT_PLATE_PRESS_SPEED_MOD
 
 	for(var/datum/stock_part/matter_bin/new_matter_bin in component_parts)
-		speed_modifier -= ((new_matter_bin.tier - 1) * 0.025)
+		speed_modifier -= ((new_matter_bin.tier - 1) * 0.03)
 
 	for(var/datum/stock_part/servo/new_servo in component_parts)
-		speed_modifier -= ((new_servo.tier - 1) * 0.05)
+		speed_modifier -= ((new_servo.tier - 1) * 0.07)
 
 	// so tier 4 bin and tier 4 servo gives
 	// 4 * 0.025 + 4 * 0.05 = 0.3 modifier reduce

--- a/modular_ss220/modules/security_minor_1984/licensepress_circuit/prisonlabor.dm
+++ b/modular_ss220/modules/security_minor_1984/licensepress_circuit/prisonlabor.dm
@@ -1,0 +1,25 @@
+#define DEFAULT_PLATE_PRESS_SPEED_MOD = 1.0
+
+/obj/machinery/plate_press
+	circuit = /obj/item/circuitboard/machine/plate_press
+	var/speed_modifier = DEFAULT_PLATE_PRESS_SPEED_MOD // recalculated on parts changed
+
+/obj/machinery/plate_press/RefreshParts()
+	. = ..()
+
+	speed_modifier = DEFAULT_PLATE_PRESS_SPEED_MOD
+
+	for(var/datum/stock_part/matter_bin/new_matter_bin in component_parts)
+		speed_modifier -= new_matter_bin.tier * 0.025
+
+	for(var/datum/stock_part/servo/new_servo in component_parts)
+		speed_modifier -= new_servo.tier * 0.5
+
+	// so tier 4 bin and tier 4 servo gives
+	// 4 * 0.025 + 4 * 0.05 = 0.3 modifier reduce
+	// 1.0 - 0.3 = 0.7 modifier, prison business is real
+
+	if (speed_modifier < 0)
+		speed_modifier = 0
+
+#undef DEFAULT_PLATE_PRESS_SPEED_MOD

--- a/modular_ss220/modules/security_minor_1984/licensepress_circuit/prisonlabor.dm
+++ b/modular_ss220/modules/security_minor_1984/licensepress_circuit/prisonlabor.dm
@@ -10,10 +10,10 @@
 	speed_modifier = DEFAULT_PLATE_PRESS_SPEED_MOD
 
 	for(var/datum/stock_part/matter_bin/new_matter_bin in component_parts)
-		speed_modifier -= new_matter_bin.tier * 0.025
+		speed_modifier -= (new_matter_bin.tier * 0.025)
 
 	for(var/datum/stock_part/servo/new_servo in component_parts)
-		speed_modifier -= new_servo.tier * 0.5
+		speed_modifier -= (new_servo.tier * 0.05)
 
 	// so tier 4 bin and tier 4 servo gives
 	// 4 * 0.025 + 4 * 0.05 = 0.3 modifier reduce
@@ -21,5 +21,44 @@
 
 	if (speed_modifier < 0)
 		speed_modifier = 0
+
+/obj/machinery/plate_press/examine(mob/user)
+	. = ..()
+
+	if(in_range(user, src) || isobserver(user))
+		. += span_notice("The status display reads:")
+		. += span_notice(" - Speed efficiency at <b>[(1 + 1 - speed_modifier) * 100]%</b>.")
+
+/obj/machinery/plate_press/screwdriver_act(mob/living/user, obj/item/tool)
+	if(!default_deconstruction_screwdriver(user, icon_state, icon_state, tool))
+		return ITEM_INTERACT_BLOCKING
+
+	if(machine_stat & MAINT)
+		set_machine_stat(machine_stat & ~MAINT)
+	else
+		set_machine_stat(machine_stat | MAINT)
+
+	pressing = FALSE
+	update_appearance()
+
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/plate_press/crowbar_act(mob/living/user, obj/item/tool)
+	if(!default_deconstruction_crowbar(tool))
+		return ITEM_INTERACT_BLOCKING
+
+	if (!isnull(current_plate))
+		var/turf/drop_location = drop_location()
+
+		if(drop_location)
+			current_plate.forceMove(drop_location)
+		else
+			current_plate.moveToNullspace()
+
+		current_plate = null
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/plate_press/proc/still_processing()
+	return pressing
 
 #undef DEFAULT_PLATE_PRESS_SPEED_MOD

--- a/modular_ss220/modules/security_minor_1984/licensepress_circuit/security_nodes.dm
+++ b/modular_ss220/modules/security_minor_1984/licensepress_circuit/security_nodes.dm
@@ -1,0 +1,3 @@
+/datum/techweb_node/sec_equip/New()
+	design_ids += "licensepress"
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9496,6 +9496,10 @@
 #include "modular_ss220\modules\security_minor_1984\service_officer\landmarks.dm"
 #include "modular_ss220\modules\security_minor_1984\corrections_officer_tweaks\corrections_officer.dm"
 #include "modular_ss220\modules\security_minor_1984\detective_closet_holster\security.dm"
+#include "modular_ss220\modules\security_minor_1984\licensepress_circuit\machine_circuitboards.dm"
+#include "modular_ss220\modules\security_minor_1984\licensepress_circuit\misc_designs.dm"
+#include "modular_ss220\modules\security_minor_1984\licensepress_circuit\security_nodes.dm"
+#include "modular_ss220\modules\security_minor_1984\licensepress_circuit\prisonlabor.dm"
 #include "modular_nova\master_files\code\game\objects\structures\crates_lockers\secure\security.dm" // have to place it here for proper double stuff
 #include "modular_ss220\modules\vote_highlight\vote.dm"
 #include "modular_ss220\modules\vote_highlight\map_vote.dm"


### PR DESCRIPTION
## Скриншоты

<img width="500" height="76" alt="image" src="https://github.com/user-attachments/assets/ce02fb39-5027-41cc-9c3e-f3c8dae975f4" />
<img width="629" height="211" alt="image" src="https://github.com/user-attachments/assets/29bde6f9-8e69-408a-9ce4-f46f3c22e60a" />
<img width="662" height="592" alt="image" src="https://github.com/user-attachments/assets/20b3ebff-a557-414f-8c08-3e8255f2da68" />

Tier 1 
<img width="1384" height="574" alt="image" src="https://github.com/user-attachments/assets/03dc1312-9bba-4144-8c6d-3ebccd43e394" />

Tier 4 (Femto servo + bluespace matter bin)
<img width="498" height="106" alt="image" src="https://github.com/user-attachments/assets/e06b974b-37b6-4b32-9f71-e399ec5ff5c3" />

## Changelog

:cl:
add: License plate press circuit is added to "Security Equipment" technode
add: License plate press machine now require 1 servo and 1 matter bin to be built
add: License plate press with upgraded matter bin provides tier * 0.03 speed efficiency after 1 tier
add: License plate press with upgraded servo provides tier * 0.07 speed efficiency after 1 tier (tier 4 bin + servo provides in total 1+0.3 efficiency, that results in 0.7 * 4 seconds delay between filling plate)
/:cl:

****
- [x] Проверено на локалке