### PR TITLE
fix: Removes blank/unused keybindings

### DIFF
--- a/code/_globalvars/lists/keybindings.dm
+++ b/code/_globalvars/lists/keybindings.dm
@@ -20,7 +20,27 @@
 				LAZYADD(GLOB.default_hotkeys[instance.name], list(bound_key))
 
 /proc/init_emote_keybinds()
-	for(var/i in subtypesof(/datum/emote))
+	// SS1984 ADDITION START
+	var/list/emotes_list = subtypesof(/datum/emote)
+	if (!emotes_list || length(emotes_list) < 1)
+		log_runtime("Emotes list is null or empty! Will skip keybindings init")
+		return
+	var/list/cyrillic_emotes_list = list()
+	for(var/i in emotes_list)
+		var/datum/emote/faketype = i
+		if(!initial(faketype.key))
+			continue
+		var/target_name = faketype.name
+		if (!target_name || length(target_name) < 1)
+			target_name = faketype.key
+		if (length(target_name) < 1)
+			continue
+		var/c1 = target_name[1]
+		if (c1 < "А" || c1 > "я")
+			continue
+		cyrillic_emotes_list += faketype
+	// SS1984 ADDITION END
+	for(var/i in cyrillic_emotes_list) // SS1984 EDIT, original: for(var/i in subtypesof(/datum/emote))
 		var/datum/emote/faketype = i
 		if(!initial(faketype.key))
 			continue

--- a/code/datums/keybinding/emote.dm
+++ b/code/datums/keybinding/emote.dm
@@ -9,6 +9,8 @@
 	classic_keys = list("Unbound")
 	emote_key = initial(faketype.key)
 	name = faketype.name // SS1984 EDIT, original: name = initial(faketype.key)
+	if (!name) // SS1984 ADDITION
+		name = emote_key // SS1984 ADDITION
 	full_name = capitalize(name) // SS1984 EDIT, original: full_name = capitalize(initial(faketype.key))
 
 /datum/keybinding/emote/down(client/user, turf/target)

--- a/modular_nova/modules/gun_safety/code/keybinding.dm
+++ b/modular_nova/modules/gun_safety/code/keybinding.dm
@@ -1,19 +1,21 @@
-/datum/keybinding/carbon/toggle_safety
-	hotkey_keys = list("ShiftF")
-	name = "toggle_safety"
-	full_name = "Toggle gun's safety mode"
-	description = "Toggles gun's safety mode in an active hand."
-	keybind_signal = COMSIG_KB_CARBON_TOGGLE_SAFETY
+// SS1984 REMOVAL START
+// /datum/keybinding/carbon/toggle_safety
+// 	hotkey_keys = list("ShiftF")
+// 	name = "toggle_safety"
+// 	full_name = "Toggle gun's safety mode"
+// 	description = "Toggles gun's safety mode in an active hand."
+// 	keybind_signal = COMSIG_KB_CARBON_TOGGLE_SAFETY
 
-/datum/keybinding/carbon/toggle_safety/down(client/user)
-	. = ..()
-	if(.)
-		return
-	var/mob/living/owner = user.mob
-	var/obj/item/gun = owner.get_active_held_item()
-	if(!gun)
-		return
-	var/datum/component/gun_safety/safety = gun.GetComponent(/datum/component/gun_safety)
-	if(!safety)
-		return
-	safety.toggle_safeties(owner)
+// /datum/keybinding/carbon/toggle_safety/down(client/user)
+// 	. = ..()
+// 	if(.)
+// 		return
+// 	var/mob/living/owner = user.mob
+// 	var/obj/item/gun = owner.get_active_held_item()
+// 	if(!gun)
+// 		return
+// 	var/datum/component/gun_safety/safety = gun.GetComponent(/datum/component/gun_safety)
+// 	if(!safety)
+// 		return
+// 	safety.toggle_safeties(owner)
+// SS1984 REMOVAL END

--- a/modular_nova/modules/indicators/code/combat_indicator.dm
+++ b/modular_nova/modules/indicators/code/combat_indicator.dm
@@ -200,19 +200,21 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 
 #undef COMBAT_NOTICE_COOLDOWN
 
-/datum/keybinding/living/combat_indicator
-	hotkey_keys = list("C")
-	name = "combat_indicator"
-	full_name = "Combat Indicator"
-	description = "Indicates that you're escalating to mechanics. YOU NEED TO USE THIS"
-	keybind_signal = COMSIG_KB_LIVING_COMBAT_INDICATOR
+// SS1984 REMOVAL START
+// /datum/keybinding/living/combat_indicator
+// 	hotkey_keys = list("C")
+// 	name = "combat_indicator"
+// 	full_name = "Combat Indicator"
+// 	description = "Indicates that you're escalating to mechanics. YOU NEED TO USE THIS"
+// 	keybind_signal = COMSIG_KB_LIVING_COMBAT_INDICATOR
 
-/datum/keybinding/living/combat_indicator/down(client/user)
-	. = ..()
-	if(.)
-		return
-	var/mob/living/L = user.mob
-	L.user_toggle_combat_indicator()
+// /datum/keybinding/living/combat_indicator/down(client/user)
+// 	. = ..()
+// 	if(.)
+// 		return
+// 	var/mob/living/L = user.mob
+// 	L.user_toggle_combat_indicator()
+// SS1984 REMOVAL END
 
 /datum/config_entry/flag/combat_indicator
 

--- a/modular_ss220/modules/paradise_keybindings/code/keybinding/living.dm
+++ b/modular_ss220/modules/paradise_keybindings/code/keybinding/living.dm
@@ -18,6 +18,3 @@
 
 /datum/keybinding/living/disable_combat_mode
 	hotkey_keys = list("1")
-
-/datum/keybinding/living/combat_indicator
-	hotkey_keys = list("V")


### PR DESCRIPTION
По сути выпиливает следующие бинды на эмоуты (они и так не показывались из-за бага, но баг стал полноценной фичей, хоть и исправился)
На всякий случай оставляю список:

```
 point
 me
 help
 tongue
 wheeze
 me
 scream
 screech
 gnarl
 roar
 mdash
 quill
 peep
 peep2
 snap2
 snap3
 awoo
 nya
 weh
 msqueak
 squeak
 merp
 bark
 squish
 meow
 hiss
 chitter
 clap
 clap1
 tilt
 blink2
 rblink
 squint
 smirk
 eyeroll
 huffs
 etwitch
 clear
 bawk
 caw
 caw2
 blep
 bork
 hoot
 growl
 woof
 baa
 baa2
 wurble
 rattle
 cackle
 warble
 trills
 rpurr
 purr
 moo
 honk1
 mggaow
 mrrp
 prbt
 gnash
 thump
 flutter
 esigh
 sweatdrop
 exclaim
 question
 realize
 annoyed
 turf
 shiftlayerup
 shiftlayerdown
 treply
 oink
 whicker
 hop
 chirp
 cluck
 moo
 ooga
 chitter
 yap
 ssmile
 meow
 purr
 woof
 honk
 bounce
 jiggle
 light
 vibrate
 moodnone
 moodsneaky
 moodsmile
 moodcat
 moodpout
 moodsad
 moodangry
 clack
 warble
 bloop
 chitter
 tongue
 squeak
 squeaks
 blank
 veryhappy
 happy
 neutral
 unsure
 confused
 sad
 bsod
 trollface
 awesome
 dorfy
 thinking
 facepalm
 friendcomputer
 blueglow
 redglow
 boop
 beep
 buzz
 buzz2
 chime
 honk
 ping
 sad
 warn
 slowclap
 dwoop
 yes
 no
 beep2
 laughtrack
 exme
```

Возможно такие как ```beep, ping, buzz...``` все же не нужно убирать, впрочем их можно вызвать и без биндов. 
Если надо будет, то проще всего их локализовать, иначе делать еще один вайтлист здесь

## Changelog

:cl:
fix: Blank keybindings removed (all emote+ panel non-localized emotes binds)
del: Deletes some non-localized keybindings (perhaps will be returned back once localized)
del: Toggle gun's safety keybinding removed (there's no gun safety added to weapons already) 
del: Combat indicator keybinding removed (there's no combat indicator for several months)
/:cl:

****
- [x] Проверено на локалке
