### PR TITLE
fix: modular dynamic runtimes

### DIFF
--- a/modular_ss220/modules/dynamic_tweaks/dynamic.dm
+++ b/modular_ss220/modules/dynamic_tweaks/dynamic.dm
@@ -16,7 +16,7 @@
 	if (!living_mob || living_mob.ssd_indicator)
 		return FALSE
 	if (issilicon(living_mob))
-		return living_mob.mind.assigned_role?.faction & FACTION_STATION // are they station role? AI, cyborgs yes
+		return living_mob.mind.assigned_role?.faction == FACTION_STATION // are they station role? AI, cyborgs yes
 	var/mob/living/carbon/human/human_mob = living_mob
 	if (!human_mob)
 		return FALSE

--- a/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
+++ b/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
@@ -42,7 +42,7 @@
 			// 2 = 2
 			// 3 = 2
 			// 4 = 2
-			for(var/tier_iter min_enemies)
+			for(var/tier_iter in min_enemies)
 				if (tier_iter < tier)
 					last_valid_tier = tier_iter
 				else

--- a/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
+++ b/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
@@ -32,18 +32,21 @@
 			// example: min_enemies for tier 1 is 5, and we checking for tier 1
 			if (tier in min_enemies)
 				return min_enemies[tier]
-			if (tier < 1)
-				return 0 // no defined min_enemies for tier zero explicitly, so use 0
 
-			var/last_valid_tier = (0 in min_enemies) ? 0 : 1 // there could be no zero index
+			// Consider we checking for tier 0 how much enemies we should have for heretics
+			// If we just return 0, then we possible get heretics in greenshifts
+			// So instead, start from the end and go until we reach target tier, then use latest that we had
+
 			// byond indexing not from 0 to len-1 is confusing sometimes, but consider that:
 			// (E) (C) (M) min_enemies = /list (4)
 			// 1 = 3
 			// 2 = 2
 			// 3 = 2
 			// 4 = 2
-			for(var/tier_iter in min_enemies)
-				if (tier_iter < tier)
+
+			var/last_valid_tier = len
+			for(var/tier_iter in len to 1 step -1)
+				if (tier_iter > tier)
 					last_valid_tier = tier_iter
 				else
 					return min_enemies[last_valid_tier]

--- a/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
+++ b/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
@@ -32,18 +32,24 @@
 			// example: min_enemies for tier 1 is 5, and we checking for tier 1
 			if (tier in min_enemies)
 				return min_enemies[tier]
-			// example: min_enemies for tier 1 is 5, but we checking for tier 0
-			// then it start from 0, last valid is 0
-			// once it reach tier 1, it use last valid (0)
-			var/last_valid_tier = 0
-			for (var/tier_iter in min_enemies)
+			if (tier < 1)
+				return 0 // no defined min_enemies for tier zero explicitly, so use 0
+
+			var/last_valid_tier = (0 in min_enemies) ? 0 : 1 // there could be no zero index
+			// byond indexing not from 0 to len-1 is confusing sometimes, but consider that:
+			// (E) (C) (M) min_enemies = /list (4)
+			// 1 = 3
+			// 2 = 2
+			// 3 = 2
+			// 4 = 2
+			for(var/tier_iter min_enemies)
 				if (tier_iter < tier)
 					last_valid_tier = tier_iter
 				else
 					return min_enemies[last_valid_tier]
 
 		// case when specified tier is higher than defined in min_enemies
-		return min_enemies[len - 1] // last defined tier num
+		return min_enemies[len] // last defined tier num
 
 	if (min_enemies > 0)
 		return min_enemies

--- a/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
+++ b/modular_ss220/modules/dynamic_tweaks/dynamic_ruleset.dm
@@ -24,13 +24,30 @@
 /datum/dynamic_ruleset/proc/get_minimal_num_of_enemies(tier = DYNAMIC_TIER_LOW)
 	if (islist(min_enemies))
 		var/len = length(min_enemies)
+
 		if (len < 1)
 			return 0
+
 		if (tier < len)
-			return min_enemies[tier]
+			// example: min_enemies for tier 1 is 5, and we checking for tier 1
+			if (tier in min_enemies)
+				return min_enemies[tier]
+			// example: min_enemies for tier 1 is 5, but we checking for tier 0
+			// then it start from 0, last valid is 0
+			// once it reach tier 1, it use last valid (0)
+			var/last_valid_tier = 0
+			for (var/tier_iter in min_enemies)
+				if (tier_iter < tier)
+					last_valid_tier = tier_iter
+				else
+					return min_enemies[last_valid_tier]
+
+		// case when specified tier is higher than defined in min_enemies
 		return min_enemies[len - 1] // last defined tier num
+
 	if (min_enemies > 0)
 		return min_enemies
+
 	return 0
 
 /datum/dynamic_ruleset/can_be_selected()


### PR DESCRIPTION
## Changelog

:cl:
fix: Fixes few progressive dynamic runtimes, silicons now correctly considered for population to roll rulesets. Also min required enemies now properly working for tier 0 (greenshift), it's just takes it from next defined tier (usually tier 1)
/:cl:

****
- [x] Проверено на локалке
