### PR TITLE
balance: reduce fish spawn & increase explosive penalty

### DIFF
--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -516,7 +516,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	examine_text += span_info("[info]: [english_list(known_fishes)].")
 
 ///How much the explosive_fishing_score impacts explosive fishing. The higher the value, the stronger the malus for repeated calls
-#define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.1 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
+#define EXPLOSIVE_FISHING_MALUS_EXPONENT 19.84 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
 ///How much the explosive_fishing_score is reduced each second.
 #define EXPLOSIVE_FISHING_RECOVERY_RATE 0.18
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -516,7 +516,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	examine_text += span_info("[info]: [english_list(known_fishes)].")
 
 ///How much the explosive_fishing_score impacts explosive fishing. The higher the value, the stronger the malus for repeated calls
-#define EXPLOSIVE_FISHING_MALUS_EXPONENT 2.20 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
+#define EXPLOSIVE_FISHING_MALUS_EXPONENT 1.488 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
 ///How much the explosive_fishing_score is reduced each second.
 #define EXPLOSIVE_FISHING_RECOVERY_RATE 0.18
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -516,7 +516,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	examine_text += span_info("[info]: [english_list(known_fishes)].")
 
 ///How much the explosive_fishing_score impacts explosive fishing. The higher the value, the stronger the malus for repeated calls
-#define EXPLOSIVE_FISHING_MALUS_EXPONENT 19.84 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
+#define EXPLOSIVE_FISHING_MALUS_EXPONENT 2.20 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
 ///How much the explosive_fishing_score is reduced each second.
 #define EXPLOSIVE_FISHING_RECOVERY_RATE 0.18
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -516,9 +516,9 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	examine_text += span_info("[info]: [english_list(known_fishes)].")
 
 ///How much the explosive_fishing_score impacts explosive fishing. The higher the value, the stronger the malus for repeated calls
-#define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
+#define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55 * 4 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
 ///How much the explosive_fishing_score is reduced each second.
-#define EXPLOSIVE_FISHING_RECOVERY_RATE 0.18
+#define EXPLOSIVE_FISHING_RECOVERY_RATE 0.18 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
 
 /datum/fish_source/proc/spawn_reward_from_explosion(atom/location, severity)
 	SIGNAL_HANDLER

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -516,9 +516,9 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	examine_text += span_info("[info]: [english_list(known_fishes)].")
 
 ///How much the explosive_fishing_score impacts explosive fishing. The higher the value, the stronger the malus for repeated calls
-#define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55 * 4 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
+#define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.1 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
 ///How much the explosive_fishing_score is reduced each second.
-#define EXPLOSIVE_FISHING_RECOVERY_RATE 0.18 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
+#define EXPLOSIVE_FISHING_RECOVERY_RATE 0.18
 
 /datum/fish_source/proc/spawn_reward_from_explosion(atom/location, severity)
 	SIGNAL_HANDLER

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -518,7 +518,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 ///How much the explosive_fishing_score impacts explosive fishing. The higher the value, the stronger the malus for repeated calls
 #define EXPLOSIVE_FISHING_MALUS_EXPONENT 1.488 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_MALUS_EXPONENT 0.55
 ///How much the explosive_fishing_score is reduced each second.
-#define EXPLOSIVE_FISHING_RECOVERY_RATE 0.18
+#define EXPLOSIVE_FISHING_RECOVERY_RATE 0.8 // SS1984 EDIT, original: #define EXPLOSIVE_FISHING_RECOVERY_RATE 0.18
 
 /datum/fish_source/proc/spawn_reward_from_explosion(atom/location, severity)
 	SIGNAL_HANDLER

--- a/modular_ss220/modules/limit_fishing/mining.dm
+++ b/modular_ss220/modules/limit_fishing/mining.dm
@@ -1,4 +1,0 @@
-/obj/item/fish/lavaloop/run_atom_armor(damage_amount, damage_type, damage_flag = 0, attack_dir, armour_penetration = 0)
-	if (damage_flag == BOMB)
-		return max_integrity
-	return ..()

--- a/modular_ss220/modules/limit_fishing/mining.dm
+++ b/modular_ss220/modules/limit_fishing/mining.dm
@@ -1,0 +1,4 @@
+/obj/item/fish/lavaloop/run_atom_armor(damage_amount, damage_type, damage_flag = 0, attack_dir, armour_penetration = 0)
+	if (damage_flag == BOMB)
+		return max_integrity
+	return ..()

--- a/modular_ss220/modules/limit_fishing/mining_ruins.dm
+++ b/modular_ss220/modules/limit_fishing/mining_ruins.dm
@@ -8,3 +8,5 @@
 	if (amount > 0)
 		fish_counts[/obj/item/fish/lavaloop] = amount
 		fish_count_regen[/obj/item/fish/lavaloop] = 1 MINUTES
+
+	..()

--- a/modular_ss220/modules/limit_fishing/mining_ruins.dm
+++ b/modular_ss220/modules/limit_fishing/mining_ruins.dm
@@ -1,0 +1,10 @@
+/datum/fish_source/lavaland/New()
+	var/amount = 0
+
+	if (/obj/item/fish/lavaloop in fish_table)
+		amount = fish_table[/obj/item/fish/lavaloop]
+		fish_table[/obj/item/fish/lavaloop] = ceil(amount / 2)
+
+	if (amount > 0)
+		fish_counts[/obj/item/fish/lavaloop] = amount
+		fish_count_regen[/obj/item/fish/lavaloop] = 1 MINUTES

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9578,4 +9578,5 @@
 #include "modular_ss220\modules\nucleations\quirks\death_consequences.dm"
 #include "modular_ss220\modules\nucleations\quirks\numb.dm"
 #include "modular_ss220\modules\nucleations\radium.dm"
+#include "modular_ss220\modules\limit_fishing\mining_ruins.dm"
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9579,4 +9579,5 @@
 #include "modular_ss220\modules\nucleations\quirks\numb.dm"
 #include "modular_ss220\modules\nucleations\radium.dm"
 #include "modular_ss220\modules\limit_fishing\mining_ruins.dm"
+#include "modular_ss220\modules\limit_fishing\mining.dm"
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9579,5 +9579,4 @@
 #include "modular_ss220\modules\nucleations\quirks\numb.dm"
 #include "modular_ss220\modules\nucleations\radium.dm"
 #include "modular_ss220\modules\limit_fishing\mining_ruins.dm"
-#include "modular_ss220\modules\limit_fishing\mining.dm"
 // END_INCLUDE


### PR DESCRIPTION
## Changelog

:cl:
balance: Lavaloop fish now is "limited" with the same amount, but with respawn time 1 minute (to prevent it's spam on lavaland)
balance: All fishing sources with explosive penalties now provide much less reward by explosions, especially rapid repeated (explosive penalty exponent 0.55 => 1.488)
balance: Explosive penalty recovery for fishing increased (0.18 => 0.8), to compensate very high penalty
/:cl:

****
- [x] Проверено на локалке