### PR TITLE
fix: modular oldstation runtimes with removed parameter

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation1984.dmm
@@ -6560,8 +6560,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
-	dir = 8;
-	chamber_id = "beta-o2"
+	dir = 8
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/space/ancientstation/beta/atmos)
@@ -8019,8 +8018,7 @@
 "TB" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
-	dir = 8;
-	chamber_id = "beta-o2"
+	dir = 8
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/o2,
@@ -8432,8 +8430,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
-	dir = 8;
-	chamber_id = "beta-n2"
+	dir = 8
 	},
 /turf/open/floor/engine/n2,
 /area/ruin/space/ancientstation/beta/atmos)
@@ -8525,8 +8522,7 @@
 "XA" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
-	dir = 8;
-	chamber_id = "beta-n2"
+	dir = 8
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/n2,


### PR DESCRIPTION
Ченжлог не нужен для рантаймов (если они не ломают что-то еще)

****
- [x] Проверено на локалке