### PR TITLE
[code] Fix immerse runtime

### DIFF
--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -269,10 +269,15 @@ GLOBAL_LIST_INIT(immerse_ignored_movable, typecacheof(list(
 /// A band-aid to keep the (unique) visual overlay from scaling and rotating along with its owner. I'm sorry.
 /datum/element/immerse/proc/on_update_transform(mob/living/source, resize, new_lying_angle, is_opposite_angle)
 	SIGNAL_HANDLER
+	// SS1984 ADDITION START
+	var/atom/movable/immerse_mask/effect_relay = generated_visual_overlays[source]
+	if (isnull(effect_relay))
+		return
+	// SS1984 ADDITION END
 	var/matrix/new_transform = matrix()
 	new_transform.Scale(1 / source.current_size)
 	new_transform.Turn(-new_lying_angle)
-	var/atom/movable/immerse_mask/effect_relay = generated_visual_overlays[source]
+	// SS1984 REMOVAL var/atom/movable/immerse_mask/effect_relay = generated_visual_overlays[source]
 	var/mutable_appearance/relay_appearance = new(effect_relay.appearance)
 	relay_appearance.transform = new_transform
 	effect_relay.appearance = relay_appearance


### PR DESCRIPTION
Чтобы получить рантайм, достаточно:
1. заспавнить 2 куклы
2. первую куклу одеть в outfit Head Of Security - Modsuit
3. зайти в каждую из них по очереди (агост)
4. через орбит с Auto-Observe попытаться посмотреть на 1 куклу (попробовать пару раз)
Вероятно связано с TG №93038

**** 
- [x] Проверено на локалке