### PR TITLE
add: updating cargo imports

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_component.dm
+++ b/modular_nova/modules/company_imports/code/armament_component.dm
@@ -116,6 +116,13 @@
 					if(!parent_console.contraband)
 						continue
 
+				if(gun_entry.high_contraband) //SS1984 ADD START
+					if(!(console_state == CARGO_CONSOLE))
+						continue
+					var/obj/machinery/computer/cargo/parent_console = parent
+					if(!(parent_console.obj_flags & EMAGGED))
+						continue //SS1984 ADD END
+
 				subcategory_items += list(list(
 					"ref" = REF(armament_entry),
 					"icon" = armament_entry.cached_base64,

--- a/modular_nova/modules/company_imports/code/armament_datums/_armament_basetype.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/_armament_basetype.dm
@@ -6,3 +6,5 @@
 	var/company_bitflag
 	/// If this requires a multitooled console to be visible
 	var/contraband = FALSE
+	/// If this requires a emagged console to be visible, SS1984 ADD
+	var/high_contraband = FALSE

--- a/modular_nova/modules/implants/code/augments_head.dm
+++ b/modular_nova/modules/implants/code/augments_head.dm
@@ -137,6 +137,8 @@
 		/obj/item/circuitboard/computer/communications,
 		/obj/machinery/computer/arcade,
 		/obj/item/circuitboard/computer/arcade,
+//		/obj/machinery/computer/cargo, //SS1984 Removal
+//		/obj/item/circuitboard/computer/cargo, //SS1984 Removal
 		/obj/machinery/computer/holodeck,
 		/obj/machinery/computer/emergency_shuttle,
 		/obj/machinery/recycler,

--- a/modular_nova/modules/implants/code/augments_head.dm
+++ b/modular_nova/modules/implants/code/augments_head.dm
@@ -137,8 +137,6 @@
 		/obj/item/circuitboard/computer/communications,
 		/obj/machinery/computer/arcade,
 		/obj/item/circuitboard/computer/arcade,
-		/obj/machinery/computer/cargo,
-		/obj/item/circuitboard/computer/cargo,
 		/obj/machinery/computer/holodeck,
 		/obj/machinery/computer/emergency_shuttle,
 		/obj/machinery/recycler,

--- a/modular_ss220/modules/cargo/code/akh_frontier1984.dm
+++ b/modular_ss220/modules/cargo/code/akh_frontier1984.dm
@@ -6,17 +6,16 @@
 
 /datum/armament_entry/company_import/akh_frontier/basic
 	subcategory = "Hand-Held Equipment"
+	cost = PAYCHECK_COMMAND * 4
 
 /datum/armament_entry/company_import/akh_frontier/basic/fock
 	item_type = /obj/item/multitool/fock
-	cost = PAYCHECK_COMMAND * 4
 	contraband = TRUE
 
 /datum/armament_entry/company_import/akh_frontier/basic/doorforcer
 	item_type = /obj/item/crowbar/large/doorforcer
 	cost = PAYCHECK_COMMAND * 6
 	contraband = TRUE
-	restricted = TRUE
 
 /datum/armament_entry/company_import/akh_frontier/basic/omni_drill
 	item_type = /obj/item/screwdriver/omni_drill
@@ -89,7 +88,7 @@
 
 /datum/armament_entry/company_import/akh_frontier/deployables
 	subcategory = "Deployable Power Equipment"
-	cost = PAYCHECK_COMMAND * 2
+	cost = PAYCHECK_COMMAND * 3
 
 /datum/armament_entry/company_import/akh_frontier/deployables/turbine
 	item_type = /obj/item/flatpacked_machine/wind_turbine
@@ -104,5 +103,31 @@
 
 /datum/armament_entry/company_import/akh_frontier/deployables/rtg
 	item_type = /obj/item/flatpacked_machine/rtg
-	cost = PAYCHECK_COMMAND * 6
+	cost = PAYCHECK_COMMAND * 7
 	restricted = TRUE
+
+/datum/armament_entry/company_import/akh_frontier/deployables/solar
+	item_type = /obj/item/flatpacked_machine/solar
+	cost = PAYCHECK_CREW * 3
+
+/datum/armament_entry/company_import/akh_frontier/deployables/solar/titaniumglass
+	item_type = /obj/item/flatpacked_machine/solar/titaniumglass
+	cost = PAYCHECK_COMMAND * 3
+
+/datum/armament_entry/company_import/akh_frontier/deployables/solar/plasmaglass
+	item_type = /obj/item/flatpacked_machine/solar/plasmaglass
+	cost = PAYCHECK_COMMAND * 5
+
+/datum/armament_entry/company_import/akh_frontier/deployables/solar/plastitaniumglass
+	item_type = /obj/item/flatpacked_machine/solar/plastitaniumglass
+	cost = PAYCHECK_COMMAND * 6
+
+/datum/armament_entry/company_import/akh_frontier/deployables/solar_tracker
+	item_type = /obj/item/flatpacked_machine/solar_tracker
+	cost = PAYCHECK_COMMAND
+
+/datum/armament_entry/company_import/akh_frontier/deployables/solar_control
+	name = "Solar Array Console Board"
+	item_type = /obj/item/circuitboard/computer/solar_control
+	description = "The circuit board for the console that controls the solar panel arrays"
+	cost = CARGO_CRATE_VALUE * 2

--- a/modular_ss220/modules/cargo/code/deforest_medical1984.dm
+++ b/modular_ss220/modules/cargo/code/deforest_medical1984.dm
@@ -128,9 +128,32 @@
 	item_type = /obj/item/storage/pill_bottle/neurine
 	cost = PAYCHECK_COMMAND * 8
 
+/datum/armament_entry/company_import/deforest/neuroware
+	subcategory = "Medical Neuroware Chips"
+	cost = PAYCHECK_CREW * 3
+
+/datum/armament_entry/company_import/deforest/neuroware/reset
+	item_type = /obj/item/disk/neuroware/reset
+
+/datum/armament_entry/company_import/deforest/neuroware/brain
+	item_type = /obj/item/disk/neuroware/brain
+
+/datum/armament_entry/company_import/deforest/neuroware/morphine
+	item_type = /obj/item/disk/neuroware/morphine
+
+/datum/armament_entry/company_import/deforest/neuroware/lidocaine
+	item_type = /obj/item/disk/neuroware/lidocaine
+
+/datum/armament_entry/company_import/deforest/neuroware/neuroware/happiness
+	item_type = /obj/item/disk/neuroware/happiness
+
+/datum/armament_entry/company_import/deforest/neuroware/synaptizine
+	item_type = /obj/item/disk/neuroware/synaptizine
+
+/datum/armament_entry/company_import/deforest/neuroware/psicodine
+	item_type = /obj/item/disk/neuroware/psicodine
 
 // Autoinjectors for healing
-
 /datum/armament_entry/company_import/deforest/medpens
 	subcategory = "Medical Autoinjectors"
 	cost = PAYCHECK_LOWER * 6
@@ -211,10 +234,13 @@
 
 /datum/armament_entry/company_import/deforest/equipment
 	subcategory = "Medical Equipment"
-
-/datum/armament_entry/company_import/deforest/equipment/health_analyzer
-	item_type = /obj/item/healthanalyzer/simple
 	cost = PAYCHECK_LOWER
+
+/datum/armament_entry/company_import/deforest/equipment/wound_analyzer
+	item_type = /obj/item/healthanalyzer/simple
+
+/datum/armament_entry/company_import/deforest/equipment/disease_analyzer
+	item_type = /obj/item/healthanalyzer/simple/disease
 
 /datum/armament_entry/company_import/deforest/equipment/health_analyzer
 	item_type = /obj/item/healthanalyzer
@@ -226,7 +252,7 @@
 
 /datum/armament_entry/company_import/deforest/equipment/treatment_zone_projector
 	item_type = /obj/item/holosign_creator/medical/treatment_zone
-	cost = PAYCHECK_COMMAND
+	cost = PAYCHECK_CREW
 
 /datum/armament_entry/company_import/deforest/equipment/loaded_defib
 	item_type = /obj/item/defibrillator/loaded
@@ -268,17 +294,21 @@
 	item_type = /obj/item/wallframe/frontier_medstation
 	cost = PAYCHECK_COMMAND * 12
 
+/datum/armament_entry/company_import/deforest/equipment/cyber_repair_paste
+	item_type = /obj/item/cybernetic_repair_paste
+	cost = PAYCHECK_COMMAND * 3
+
 // Advanced implants, some of these can be printed but this is a way to get them before tech if you REALLY wanted
 
 /datum/armament_entry/company_import/deforest/cyber_implants
-	subcategory = "Cybernetic Implants"
+	subcategory = "Combat Cybernetic Implants"
 	cost = PAYCHECK_COMMAND * 3
+	restricted = TRUE
 
 /datum/armament_entry/company_import/deforest/cyber_implants/razorwire
 	name = "Razorwire Spool Implant"
 	item_type = /obj/item/organ/cyberimp/arm/toolkit/razorwire
 	cost = PAYCHECK_COMMAND * 6
-	restricted = TRUE
 
 /datum/armament_entry/company_import/deforest/cyber_implants/shell_launcher
 	name = "Shell Launch System Implant"

--- a/modular_ss220/modules/cargo/code/jarnsmiour1984.dm
+++ b/modular_ss220/modules/cargo/code/jarnsmiour1984.dm
@@ -27,7 +27,13 @@
 	restricted = TRUE
 	cost = PAYCHECK_COMMAND * 10
 
-/datum/armament_entry/company_import/blacksteel/blade/combat_knide
+/datum/armament_entry/company_import/blacksteel/blade/switchblade
+	item_type = /obj/item/switchblade
+	contraband = TRUE
+	restricted = TRUE
+	cost = PAYCHECK_COMMAND * 14
+
+/datum/armament_entry/company_import/blacksteel/blade/combat_knife
 	item_type = /obj/item/knife/combat
 	contraband = TRUE
 	restricted = TRUE
@@ -60,6 +66,7 @@
 
 /datum/armament_entry/company_import/blacksteel/equipment
 	subcategory = "Medieval Equipment"
+	cost = PAYCHECK_COMMAND * 3
 
 /datum/armament_entry/company_import/blacksteel/equipment/belt
 	item_type = /obj/item/storage/belt/crusader
@@ -67,7 +74,6 @@
 
 /datum/armament_entry/company_import/blacksteel/equipment/cuirass
 	item_type = /obj/item/clothing/suit/armor/vest/cuirass
-	cost = PAYCHECK_COMMAND * 3
 
 /datum/armament_entry/company_import/blacksteel/equipment/quiver
 	item_type = /obj/item/storage/bag/quiver/full

--- a/modular_ss220/modules/cargo/code/kahraman_industries1984.dm
+++ b/modular_ss220/modules/cargo/code/kahraman_industries1984.dm
@@ -15,7 +15,7 @@
 
 /datum/armament_entry/company_import/kahraman/basic/fireproof_spray
 	item_type = /obj/item/fireproof_spray
-
+	cost = PAYCHECK_COMMAND * 4
 
 /// Kahraman-made machines
 /datum/armament_entry/company_import/kahraman/machinery
@@ -119,4 +119,4 @@
 
 /datum/armament_entry/company_import/kahraman/storage_equipment/vest
 	item_type = /obj/item/storage/belt/webbing/colonial
-	cost = PAYCHECK_COMMAND * 2
+	cost = PAYCHECK_COMMAND

--- a/modular_ss220/modules/cargo/code/microstar_energy1984.dm
+++ b/modular_ss220/modules/cargo/code/microstar_energy1984.dm
@@ -6,25 +6,42 @@
 
 /datum/armament_entry/company_import/microstar/basic_energy_weapons
 	subcategory = "Basic Energy Smallarms"
+	restricted = TRUE
+
+/datum/armament_entry/company_import/microstar/basic_energy_weapons/disabler
+	item_type = /obj/item/gun/energy/disabler
+	cost = PAYCHECK_COMMAND * 7
+
+/datum/armament_entry/company_import/microstar/basic_energy_weapons/disabler_smg
+	item_type = /obj/item/gun/energy/disabler/smg
+	cost = PAYCHECK_COMMAND * 14
+	contraband = TRUE
+
+/datum/armament_entry/company_import/microstar/basic_energy_weapons/advtaser
+	item_type = /obj/item/gun/energy/e_gun/advtaser
+	cost = PAYCHECK_COMMAND * 8
 
 /datum/armament_entry/company_import/microstar/basic_energy_weapons/mini_egun
 	item_type = /obj/item/gun/energy/e_gun/mini
 	cost = PAYCHECK_COMMAND * 10
+	restricted = FALSE
 
-/datum/armament_entry/company_import/microstar/basic_energy_weapons/advtaser
-	item_type = /obj/item/gun/energy/e_gun/advtaser
-	cost = PAYCHECK_COMMAND * 12
+/datum/armament_entry/company_import/microstar/basic_energy_long_weapons
+	subcategory = "Basic Energy Longarms"
+	restricted = TRUE
+
+/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/laser
+	item_type = /obj/item/gun/energy/laser
+	cost = PAYCHECK_COMMAND * 5
+
+/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/laser_carbine
+	item_type = /obj/item/gun/energy/laser/carbine
+	cost = PAYCHECK_COMMAND * 13
 	contraband = TRUE
 
-/datum/armament_entry/company_import/microstar/basic_energy_weapons/disabler
-	item_type = /obj/item/gun/energy/disabler
-	cost = PAYCHECK_COMMAND * 9
-	restricted = TRUE
-
-/datum/armament_entry/company_import/microstar/basic_energy_weapons/disabler_smg
-	item_type = /obj/item/gun/energy/disabler/smg
+/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/egun
+	item_type = /obj/item/gun/energy/e_gun
 	cost = PAYCHECK_COMMAND * 15
-	restricted = TRUE
 
 // Preset 'loadout' kits built around a barrel attachment
 

--- a/modular_ss220/modules/cargo/code/nakamura_modsuits1984.dm
+++ b/modular_ss220/modules/cargo/code/nakamura_modsuits1984.dm
@@ -35,6 +35,7 @@
 
 /datum/armament_entry/company_import/nakamura_modsuits/core/plasma
 	item_type = /obj/item/mod/core/plasma
+	cost = PAYCHECK_COMMAND * 1.5
 
 /datum/armament_entry/company_import/nakamura_modsuits/core/ethereal
 	item_type = /obj/item/mod/core/ethereal
@@ -65,12 +66,13 @@
 /datum/armament_entry/company_import/nakamura_modsuits/plating/security
 	name = "MOD Security Plating"
 	item_type = /obj/item/mod/construction/plating/security
-	cost = PAYCHECK_COMMAND * 2
+	cost = PAYCHECK_COMMAND * 3
+	restricted = TRUE
 
 /datum/armament_entry/company_import/nakamura_modsuits/plating/clown
 	name = "MOD CosmoHonk (TM) Plating"
 	item_type = /obj/item/mod/construction/plating/cosmohonk
-	cost = PAYCHECK_COMMAND * 2
+	cost = PAYCHECK_COMMAND * 4
 	contraband = TRUE
 
 // MOD modules
@@ -112,7 +114,7 @@
 
 /datum/armament_entry/company_import/nakamura_modsuits/utility_modules/regulator
 	item_type = /obj/item/mod/module/thermal_regulator
-	cost = PAYCHECK_LOWER * 2
+	cost = PAYCHECK_CREW
 
 /datum/armament_entry/company_import/nakamura_modsuits/utility_modules/mouthhole
 	item_type = /obj/item/mod/module/mouthhole
@@ -174,7 +176,7 @@
 
 /datum/armament_entry/company_import/nakamura_modsuits/mobility_modules/atrocinator
 	item_type = /obj/item/mod/module/atrocinator
-	cost = PAYCHECK_COMMAND * 6
+	cost = PAYCHECK_COMMAND * 5
 	contraband = TRUE
 
 // Novelty modules, goofy stuff that's rare/unprintable, but doesn't fit in any of the above categories

--- a/modular_ss220/modules/cargo/code/nri_military_surplus1984.dm
+++ b/modular_ss220/modules/cargo/code/nri_military_surplus1984.dm
@@ -103,6 +103,10 @@
 	subcategory = "Miscellaneous Supplies"
 	cost = PAYCHECK_CREW
 
+/datum/armament_entry/company_import/nri_surplus/misc/stun_gun //Not a gun but it's only fair to place similar items close to each other
+	item_type = /obj/item/melee/baton/security/stun_gun/loaded
+	cost = PAYCHECK_COMMAND * 5 //Similarly live action roleplay'iy stun baton lite
+
 /datum/armament_entry/company_import/nri_surplus/misc/flares
 	item_type = /obj/item/storage/box/nri_flares
 	cost = PAYCHECK_LOWER
@@ -139,36 +143,77 @@
 	cost = PAYCHECK_LOWER
 	contraband = TRUE
 
-/datum/armament_entry/company_import/nri_surplus/firearm
-	subcategory = "Firearms"
+/datum/armament_entry/company_import/nri_surplus/sidearm
+	subcategory = "Sidearms"
 	cost = PAYCHECK_COMMAND * 12
 	restricted = TRUE
 
-/datum/armament_entry/company_import/nri_surplus/firearm/shotgun_revolver
+/datum/armament_entry/company_import/nri_surplus/sidearm/shotgun_revolver
 	item_type = /obj/item/gun/ballistic/revolver/shotgun_revolver
 	contraband = TRUE
 
-/datum/armament_entry/company_import/nri_surplus/firearm/zashch
+/datum/armament_entry/company_import/nri_surplus/sidearm/zashch
 	item_type = /obj/item/gun/ballistic/automatic/pistol/zashch
 	contraband = TRUE
 
-/datum/armament_entry/company_import/nri_surplus/firearm/plasma_thrower
+/datum/armament_entry/company_import/nri_surplus/sidearm/plasma_thrower
 	item_type = /obj/item/gun/ballistic/automatic/pistol/plasma_thrower
 	contraband = TRUE
 
-/datum/armament_entry/company_import/nri_surplus/firearm/plasma_marksman
+/datum/armament_entry/company_import/nri_surplus/sidearm/plasma_marksman
 	item_type = /obj/item/gun/ballistic/automatic/pistol/plasma_marksman
 	contraband = TRUE
 
-/datum/armament_entry/company_import/nri_surplus/firearm/crank_taser
+/datum/armament_entry/company_import/nri_surplus/sidearm/crank_taser
 	item_type = /obj/item/gun/energy/taser/crank
 	cost = PAYCHECK_COMMAND * 15 //No disabler, less charge in general in comparison to a normal double-mode taser; yet chargable on the spot (even if unwieldy)
 	restricted = FALSE
 
-/datum/armament_entry/company_import/nri_surplus/firearm/stun_gun //Not a gun but it's only fair to place similar items close to each other
-	item_type = /obj/item/melee/baton/security/stun_gun/loaded
-	cost = PAYCHECK_COMMAND * 5 //Similarly live action roleplay'iy stun baton lite
+/datum/armament_entry/company_import/nri_surplus/longarm
+	subcategory = "Longarms"
+	cost = PAYCHECK_COMMAND * 16
+	restricted = TRUE
+
+/datum/armament_entry/company_import/nri_surplus/longarm/lanca
+	item_type = /obj/item/gun/ballistic/rifle/sporterized/qmr
+	cost = PAYCHECK_COMMAND * 20
 	restricted = FALSE
+
+/*
+/datum/armament_entry/company_import/nri_surplus/longarm/sakhno_rifle
+	item_type = /obj/item/gun/ballistic/rifle/boltaction
+	cost = PAYCHECK_COMMAND * 20
+
+/datum/armament_entry/company_import/nri_surplus/longarm/lanca
+	item_type = /obj/item/gun/ballistic/automatic/lanca
+	cost = PAYCHECK_COMMAND * 24
+	contraband = TRUE
+
+/datum/armament_entry/company_import/nri_surplus/longarm/miecz
+	item_type = /obj/item/gun/ballistic/automatic/miecz
+	cost = PAYCHECK_COMMAND * 16
+	contraband = TRUE
+
+/datum/armament_entry/company_import/nri_surplus/longarm/napad
+	item_type = /obj/item/gun/ballistic/automatic/napad
+	cost = PAYCHECK_COMMAND * 19
+	contraband = TRUE
+
+/datum/armament_entry/company_import/nri_surplus/longarm/pulse_rifle
+	item_type = /obj/item/gun/ballistic/automatic/pulse_rifle
+	cost = PAYCHECK_COMMAND * 25
+	contraband = TRUE
+
+/datum/armament_entry/company_import/nri_surplus/longarm/pulse_sniper //for other time
+	item_type = /obj/item/gun/ballistic/rifle/pulse_sniper
+	cost = PAYCHECK_COMMAND * 22
+	contraband = TRUE
+
+/datum/armament_entry/company_import/nri_surplus/longarm/anti_materiel_rifle
+	item_type = /obj/item/gun/ballistic/automatic/wylom
+	cost = PAYCHECK_COMMAND * 36
+	contraband = TRUE
+*/
 
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo
 	subcategory = "Firearm Magazines"
@@ -187,6 +232,11 @@
 	item_type = /obj/item/ammo_box/magazine/miecz/spawns_empty
 	contraband = TRUE
 
+/datum/armament_entry/company_import/nri_surplus/firearm_ammo/napad
+	item_type = /obj/item/ammo_box/magazine/napad/spawns_empty
+	cost = PAYCHECK_CREW * 4
+	contraband = TRUE
+
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo/sakhno
 	item_type = /obj/item/ammo_box/speedloader/strilka310
 	cost = PAYCHECK_CREW * 6
@@ -196,9 +246,14 @@
 	contraband = TRUE
 
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo/lanca_qm
-	item_type = /obj/item/ammo_box/magazine/lanca/qmr/empty
-	cost = PAYCHECK_CREW
+	item_type = /obj/item/ammo_box/magazine/lanca/qmr
+	cost = PAYCHECK_CREW * 3
 	restricted = FALSE
+
+/datum/armament_entry/company_import/nri_surplus/firearm_ammo/zaibas
+	item_type = /obj/item/ammo_box/magazine/pulse/spawns_empty
+	cost = PAYCHECK_CREW * 4
+	contraband = TRUE
 
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo/amr_magazine
 	item_type = /obj/item/ammo_box/magazine/wylom

--- a/modular_ss220/modules/cargo/code/put_a_donk_on_it1984.dm
+++ b/modular_ss220/modules/cargo/code/put_a_donk_on_it1984.dm
@@ -83,6 +83,26 @@
 /datum/armament_entry/company_import/donk/merch/valid_bloon
 	item_type = /obj/item/toy/balloon/arrest
 
+/datum/armament_entry/company_import/donk/merch/neuroware
+	subcategory = "Donk Co. Neuroware Chips"
+	cost = PAYCHECK_COMMAND
+	contraband = TRUE
+
+/datum/armament_entry/company_import/donk/merch/neuroware/blastoff
+	item_type = /obj/item/disk/neuroware/blastoff
+
+/datum/armament_entry/company_import/donk/merch/neuroware/mindbreaker
+	item_type = /obj/item/disk/neuroware/mindbreaker
+
+/datum/armament_entry/company_import/donk/merch/neuroware/mushroomhallucinogen
+	item_type = /obj/item/disk/neuroware/mushroomhallucinogen
+
+/datum/armament_entry/company_import/donk/merch/neuroware/space_drugs
+	item_type = /obj/item/disk/neuroware/space_drugs
+
+/datum/armament_entry/company_import/donk/merch/neuroware/thc
+	item_type = /obj/item/disk/neuroware/thc
+
 // Donksoft weapons
 
 /datum/armament_entry/company_import/donk/foamforce

--- a/modular_ss220/modules/cargo/code/vitezstvi_ammo1984.dm
+++ b/modular_ss220/modules/cargo/code/vitezstvi_ammo1984.dm
@@ -21,12 +21,6 @@
 	item_type = /obj/item/ammo_workbench_module/lethal
 	cost = PAYCHECK_COMMAND * 3
 
-// not a disk. adds print points
-// /datum/armament_entry/company_import/vitezstvi/ammo_bench/reboot
-// 	name = "reusable module reauthenticator"
-// 	item_type = /obj/item/ammo_workbench_reboot
-// 	cost = PAYCHECK_CREW
-
 // disk but with the bits needed for EMP/fire bullets
 /datum/armament_entry/company_import/vitezstvi/ammo_bench/ammo_disk/lethal_gimmick
 	item_type = /obj/item/ammo_workbench_module/lethal_gimmick
@@ -69,6 +63,8 @@
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes
 	subcategory = "Ammunition Boxes"
 	cost = PAYCHECK_CREW
+	restricted = FALSE
+	contraband = FALSE
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/lethal
 	cost = PAYCHECK_COMMAND
@@ -83,7 +79,6 @@
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/rubber_9mm
 	item_type = /obj/item/ammo_box/c9mm/rubber
-	restricted = FALSE
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/lethal/cal_10mm
 	item_type = /obj/item/ammo_box/c10mm
@@ -94,14 +89,12 @@
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/rubber_10mm
 	item_type = /obj/item/ammo_box/c10mm/rubber
-	restricted = FALSE
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/lethal/cal_310
 	item_type = /obj/item/ammo_box/c310_cargo_box
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/rubber_310
 	item_type = /obj/item/ammo_box/c310_cargo_box/rubber
-	restricted = FALSE
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/lethal/ap_310
 	item_type = /obj/item/ammo_box/c310_cargo_box/piercing
@@ -120,7 +113,6 @@
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/sol35_disabler
 	item_type = /obj/item/ammo_box/c35sol/incapacitator
-	restricted = FALSE
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/lethal/sol35_ripper
 	item_type = /obj/item/ammo_box/c35sol/ripper
@@ -131,7 +123,6 @@
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/sol40_disabler
 	item_type = /obj/item/ammo_box/c40sol/fragmentation
-	restricted = FALSE
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/lethal/sol40_flame
 	item_type = /obj/item/ammo_box/c40sol/incendiary
@@ -146,7 +137,6 @@
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/trappiste585_disabler
 	item_type = /obj/item/ammo_box/c585trappiste/incapacitator
-	restricted = FALSE
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/lethal/trappiste585_incendiary
 	item_type = /obj/item/ammo_box/c585trappiste/incendiary
@@ -154,7 +144,11 @@
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/kineticballs
 	item_type = /obj/item/ammo_box/advanced/kineticballs
-	restricted = FALSE
+
+/datum/armament_entry/company_import/vitezstvi/ammo_boxes/lethal/pulse_gun_ammo
+	item_type = /obj/item/ammo_box/pulse_cargo_box
+	cost = PAYCHECK_COMMAND * 5
+	contraband = TRUE
 
 // Revolver speedloaders
 
@@ -219,9 +213,11 @@
 /datum/armament_entry/company_import/vitezstvi/grenade_shells
 	subcategory = "Grenade Shells"
 	cost = PAYCHECK_COMMAND
+	restricted = TRUE
 
 /datum/armament_entry/company_import/vitezstvi/grenade_shells/practice
 	item_type = /obj/item/ammo_box/c980grenade
+	restricted = FALSE
 
 /datum/armament_entry/company_import/vitezstvi/grenade_shells/smoke
 	item_type = /obj/item/ammo_box/c980grenade/smoke
@@ -232,11 +228,9 @@
 /datum/armament_entry/company_import/vitezstvi/grenade_shells/shrapnel
 	item_type = /obj/item/ammo_box/c980grenade/shrapnel
 	cost = PAYCHECK_COMMAND * 2
-	restricted = TRUE
 	contraband = TRUE
 
 /datum/armament_entry/company_import/vitezstvi/grenade_shells/phosphor
 	item_type = /obj/item/ammo_box/c980grenade/shrapnel/phosphor
 	cost = PAYCHECK_COMMAND * 3
-	restricted = TRUE
 	contraband = TRUE


### PR DESCRIPTION
## Описание
Обновил импорты карго добавив вещей нов, добавил чуть нового контента(нейрочипы для синтов), немного рассортировал предметы, слегка обновил цены, добавил доп пункт "высокой" контрабанды, потом можно будет перенастроить некоторые вещи из импортов на него


## Changelog

:cl:
add: Added new items to imports from offs(synth neuroware, some more flatpacks)
fix: fixed missing wound/decease analyzer in import
del: Removed restriction for hacking cargo console with emag implant
qol: separated longarms from pistols in nri import
qol: moved a couple of items in the import list(energy weapons import and taser item from nri guns to nri items) for a more beautiful look
balance: rebalanced some cargo import items price
/:cl:


- [x] Проверено на локалке
