### PR TITLE
spellcheck: remove 's ending from localized emotions

### DIFF
--- a/config/nova/interactions/fistbump.json
+++ b/config/nova/interactions/fistbump.json
@@ -4,7 +4,7 @@
 	"usage": "other",
 	"category": "Miscellaneous",
 	"distance_allowed": 0,
-	"message": ["%USER% ударяет кулак %TARGET%'s о свой!"],
+	"message": ["%USER% ударяет кулак %TARGET% о свой!"],
 	"sound_use": 0,
 	"sound_possible": [],
 	"sound_range": 7,

--- a/config/nova/interactions/handshake.json
+++ b/config/nova/interactions/handshake.json
@@ -4,7 +4,7 @@
 	"usage": "other",
 	"category": "Miscellaneous",
 	"distance_allowed": 0,
-	"message": ["%USER% жмет руку %TARGET%'s."],
+	"message": ["%USER% жмет руку %TARGET%."],
 	"sound_use": 0,
 	"sound_possible": [],
 	"sound_range": 7,

--- a/config/nova/interactions/headpat.json
+++ b/config/nova/interactions/headpat.json
@@ -4,7 +4,7 @@
 	"usage": "other",
 	"category": "Miscellaneous",
 	"distance_allowed": 0,
-	"message": ["%USER% гладит по голове %TARGET%'s!"],
+	"message": ["%USER% гладит по голове %TARGET%!"],
 	"sound_use": 0,
 	"sound_possible": [],
 	"sound_range": 7,


### PR DESCRIPTION
## Changelog

:cl:
spellcheck: Removed 's ending form localized interactions, such as headpat, fistbump, handshake
/:cl:

****
- [x] Проверено на локалке
