### PR TITLE
fix: loot panel harddel fix

### DIFF
--- a/code/modules/lootpanel/contents.dm
+++ b/code/modules/lootpanel/contents.dm
@@ -38,7 +38,7 @@
 	window?.send_update()
 
 	if(length(to_image))
-		SSlooting.backlog += src
+		SSlooting.backlog += WEAKREF(src) // SS1984 EDIT, original: SSlooting.backlog += src
 
 
 /// For: Resetting to empty. Ignores the searchable qdel event

--- a/code/modules/lootpanel/ss_looting.dm
+++ b/code/modules/lootpanel/ss_looting.dm
@@ -26,13 +26,20 @@ SUBSYSTEM_DEF(looting)
 		backlog = list()
 
 	while(length(processing))
-		var/datum/lootpanel/panel = processing[length(processing)]
+		// SS1984 ADDITION START
+		var/datum/weakref/panel_ref = processing[length(processing)]
+		var/datum/lootpanel/panel = panel_ref.resolve()
+		if (isnull(panel_ref))
+			processing.len--
+			continue
+		// SS1984 ADDITION END
+		// SS1984 REMOVAL var/datum/lootpanel/panel = processing[length(processing)]
 		if(QDELETED(panel) || !length(panel.to_image))
 			processing.len--
 			continue
 
 		if(!panel.process_images())
-			backlog += panel
+			backlog += panel_ref // SS1984 EDIT, original: backlog += panel
 
 		if(MC_TICK_CHECK)
 			return

--- a/code/modules/lootpanel/ss_looting.dm
+++ b/code/modules/lootpanel/ss_looting.dm
@@ -28,7 +28,11 @@ SUBSYSTEM_DEF(looting)
 	while(length(processing))
 		// SS1984 ADDITION START
 		var/datum/weakref/panel_ref = processing[length(processing)]
-		var/datum/lootpanel/panel = panel_ref.resolve()
+		var/datum/lootpanel/panel
+		if (isnull(panel_ref) || !isweakref(panel_ref))
+			panel = processing[length(processing)] // perhaps it placed not weakref somehow by upstreams
+		else
+			panel = panel_ref.resolve()
 		if (isnull(panel_ref))
 			processing.len--
 			continue


### PR DESCRIPTION
Ченжлог не нужен, проверить полноценно затруднительно. 

Могло возникнуть спонтанно через полчаса/час открытой локалки с заспавненными мобами + открытым однажды окном лут панели. Возможно клиент крашнулся и лут панель осталась в списке