### PR TITLE
code: updated armour and other modsuits thing

### DIFF
--- a/modular_ss220/modules/modsuits/code/modsuit.dm
+++ b/modular_ss220/modules/modsuits/code/modsuit.dm
@@ -26,8 +26,8 @@
 	melee = 45
 	bullet = 45
 	laser = 30
-	energy = 35
-	bomb = 25
+	energy = 40
+	bomb = 30
 	bio = 100
 	fire = 80
 	acid = 80
@@ -164,11 +164,11 @@
 //ntr corporate
 
 /datum/armor/mod_theme_corporate_official
-	melee = 20
+	melee = 25
 	bullet = 20
-	laser = 15
-	energy = 15
-	bomb = 25
+	laser = 20
+	energy = 20
+	bomb = 30
 	bio = 100
 	fire = 75
 	acid = 75
@@ -188,7 +188,8 @@
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	charge_drain = DEFAULT_CHARGE_DRAIN
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
-	slowdown_deployed = 0.35
+	slowdown_deployed = 0.25
+	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
 	allowed_suit_storage = list(
 		/obj/item/assembly/flash,
 		/obj/item/melee/baton,

--- a/modular_ss220/modules/rolesedit/code/jobs/blueshield.dm
+++ b/modular_ss220/modules/rolesedit/code/jobs/blueshield.dm
@@ -66,7 +66,7 @@
 
 //modsuit
 /datum/armor/mod_theme_blueshield
-	melee = 40
+	melee = 45
 	bullet = 30
 	laser = 30
 	energy = 40
@@ -74,7 +74,7 @@
 	bio = 100
 	fire = 100
 	acid = 100
-	wound = 20
+	wound = 25
 
 /datum/mod_theme/blueshield
 	armor_type = /datum/armor/mod_theme_blueshield
@@ -83,13 +83,13 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 3
-	inbuilt_modules = list(/obj/item/mod/module/shove_blocker/locked)
+	inbuilt_modules = list(/obj/item/mod/module/shove_blocker/locked, /obj/item/mod/module/hearing_protection)
 
 /obj/item/mod/control/pre_equipped/blueshield
 	req_access = list(ACCESS_CENT_GENERAL)
 	applied_modules = list(
 		/obj/item/mod/module/quick_cuff,
-		/obj/item/mod/module/storage,
+		/obj/item/mod/module/storage/large_capacity,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/projectile_dampener,


### PR DESCRIPTION
## Описание
surplus security -  energy 35 > 40,  bomb 25 > 30
БЩ - melee 40 > 45, wound 20 > 25 (до обновленного оффами уровня защиты мода гсб) Добавлен модуль защиты от шума(как и у остальных боевых/цк модов), (так же стартово не обделен обычным хранилищем, это так же обновили новы)
НТР - slowdown_deployed 0.35 > 0.25. melee 20 > 25, laser 15 > 20, energy 15 > 20, bomb 25 > 30 (чтобы слегка менее отставать от мода сб после его мини баффа оффами), так же добавлена защита от флешек
## Changelog

:cl:
balance: Updated Blueshield MODsuit: Armour buff 40>45 melee, 20>25 wound. Added loud sound protection module and expanded storage module. 
balance: Updated NTR corporate MODsuit: slowdown decreased 0.35 > 0.25. Armour buff: melee 20 > 25, laser 15 > 20, energy 15 > 20, bomb 25 > 30, added loud sound protection module.
balance: Updated Surplus Security MODsuit protection: energy 35 > 40,  bomb 25 > 30.
/:cl:


- [x] Проверено на локалке
