### PR TITLE
fix: cargo goody buy

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -314,7 +314,7 @@
 				say("ERROR: User lacks the requisite access for this purchase request.")
 				return
 
-	if(((pack.order_flags & ORDER_GOODY) && (!(pack.order_flags & ORDER_DEPARTMENTAL_GOODY) || uses_cargo_budget)) && (!self_paid || !requestonly))
+	if(((pack.order_flags & ORDER_GOODY) && (!(pack.order_flags & ORDER_DEPARTMENTAL_GOODY) || uses_cargo_budget)) && (!self_paid)) //Celadon EDIT original: if(((pack.order_flags & ORDER_GOODY) && (!(pack.order_flags & ORDER_DEPARTMENTAL_GOODY) || uses_cargo_budget)) && (!self_paid || !requestonly))
 		playsound(src, 'sound/machines/buzz/buzz-sigh.ogg', 50, FALSE)
 		say("ERROR: Small crates may only be purchased by private accounts.")
 		return


### PR DESCRIPTION
## Описание
Карго консоль теперь может оформлять заказы из раздела goody(исправил баг с проверкой)


## Changelog

:cl:
fix: cargo goody items now can be purchased from not public console
/:cl:

- [x] Проверено на локалке