### PR TITLE
fix/admin: autotransfer message

### DIFF
--- a/modular_celadon/modules/votes_stuff/transfer_vote.dm
+++ b/modular_celadon/modules/votes_stuff/transfer_vote.dm
@@ -63,3 +63,9 @@
 		choices[CHOICE_CONTINUE] += length(non_voters)
 
 	return ..()
+
+/datum/controller/subsystem/autotransfer/new_shift(real_round_start_time)
+	if(!CONFIG_GET(flag/autotransfer))	// autotransfer enabled?
+		return
+
+	return ..()


### PR DESCRIPTION
## Описание
при старте сервера теперь админы не получают уведомление о включенном автотрансфере если автотрансфер не включен


## Changelog

:cl:
admin: admins no longer receive fake message about autotranfer enabled while autotransfer disabled in config
/:cl:

- [x] Проверено на локалке