### PR TITLE
fix: nova transfervote override remove

### DIFF
--- a/modular_nova/modules/autotransfer/code/transfer_vote.dm
+++ b/modular_nova/modules/autotransfer/code/transfer_vote.dm
@@ -25,7 +25,7 @@
 	if(forced)
 		return VOTE_AVAILABLE
 
-	if(!CONFIG_GET(flag/autotransfer) || !CONFIG_GET(flag/allow_vote_transfer))
+	if(!CONFIG_GET(flag/allow_vote_transfer)) //Celadon Edit, original: if(!CONFIG_GET(flag/autotransfer) || !CONFIG_GET(flag/allow_vote_transfer))
 		return "Transfer voting is disabled."
 
 	return VOTE_AVAILABLE


### PR DESCRIPTION
## Описание
убрал оверрайд файла нов, теперь голосование точно можно активировать


## Changelog

:cl:
fix: transfer vote finally again doesnt require autotranfer enabled
/:cl:


- [x] Проверено на локалке