### PR TITLE
fix: syndicate gold card

### DIFF
--- a/modular_celadon/modules/infinite_access_slots/cards_ids.dm
+++ b/modular_celadon/modules/infinite_access_slots/cards_ids.dm
@@ -13,6 +13,9 @@
 /obj/item/card/id/advanced/prisoner
 	wildcard_expanded = null
 
+/obj/item/card/id/advanced/gold
+	wildcard_expanded = null
+
 /obj/item/card/id/advanced/centcom
 	wildcard_expanded = null
 


### PR DESCRIPTION
## Описание
золотая синди карта более не теряет лимит доступа синдиката


## Changelog

:cl:
fix: gold syndicate card no longer get downgraded to basic gold card
/:cl: